### PR TITLE
Use six module to minimize compat.py

### DIFF
--- a/airtest/aircv/aircv.py
+++ b/airtest/aircv/aircv.py
@@ -5,7 +5,7 @@ import sys
 import cv2
 import numpy as np
 from .error import FileNotExistError
-from airtest.utils.compat import PY3
+from six import PY3
 
 
 def imread(filename):

--- a/airtest/core/android/adb.py
+++ b/airtest/core/android/adb.py
@@ -1,20 +1,27 @@
 # -*- coding: utf-8 -*-
-import subprocess
-import threading
-import platform
-import warnings
-import random
-import time
-import sys
 import os
+import platform
+import random
 import re
-from airtest.core.error import AirtestError, AdbError, AdbShellError, DeviceConnectionError
-from airtest.utils.nbsp import NonBlockingStreamReader
+import subprocess
+import sys
+import threading
+import time
+import warnings
+
+from six import PY3, text_type
+from six.moves import reduce
+
+from airtest.core.android.constant import (DEFAULT_ADB_PATH, IP_PATTERN,
+                                           SDK_VERISON_NEW)
+from airtest.core.error import (AdbError, AdbShellError, AirtestError,
+                                DeviceConnectionError)
+from airtest.utils.compat import decode_path
 from airtest.utils.logger import get_logger
+from airtest.utils.nbsp import NonBlockingStreamReader
 from airtest.utils.retry import retries
-from airtest.utils.snippet import reg_cleanup, split_cmd, get_std_encoding
-from airtest.utils.compat import PY3, decode_path
-from airtest.core.android.constant import SDK_VERISON_NEW, DEFAULT_ADB_PATH, IP_PATTERN
+from airtest.utils.snippet import get_std_encoding, reg_cleanup, split_cmd
+
 # LOGGING = get_logger('adb')
 LOGGING = get_logger(__name__)
 
@@ -305,7 +312,7 @@ class ADB(object):
             return out.decode(self.SHELL_ENCODING)
         except UnicodeDecodeError:
             warnings.warn("shell output decode {} fail. repr={}".format(self.SHELL_ENCODING, repr(out)))
-            return unicode(repr(out))
+            return text_type(repr(out))
 
     def shell(self, cmd):
         """

--- a/airtest/core/android/android.py
+++ b/airtest/core/android/android.py
@@ -1,6 +1,5 @@
 #! /usr/bin/env python
 # -*- coding: utf-8 -*-
-
 import re
 import warnings
 
@@ -175,7 +174,7 @@ class Android(Device):
         # output cv2 object
         try:
             screen = aircv.utils.string_2_img(screen)
-        except:
+        except Exception:
             # may be black/locked screen or other reason, print exc for debugging
             import traceback
             traceback.print_exc()

--- a/airtest/core/android/ime.py
+++ b/airtest/core/android/ime.py
@@ -1,10 +1,9 @@
 # coding=utf-8
 import re
-from airtest.utils.compat import text_type
-from airtest.utils.snippet import on_method_ready
 from airtest.core.android.yosemite import Yosemite
 from airtest.core.error import AdbError
 from .constant import YOSEMITE_IME_SERVICE
+from six import text_type
 
 
 def ensure_unicode(value):

--- a/airtest/core/android/minicap.py
+++ b/airtest/core/android/minicap.py
@@ -4,10 +4,8 @@ import re
 import json
 import struct
 import threading
-import traceback
+import six
 from airtest.core.android.constant import STFLIB
-from airtest.core.error import AdbShellError
-from airtest.utils.compat import PY3
 from airtest.utils.logger import get_logger
 from airtest.utils.nbsp import NonBlockingStreamReader
 from airtest.utils.safesocket import SafeSocket
@@ -298,11 +296,7 @@ class Minicap(object):
         with self.stream_lock:
             if self.frame_gen is None:
                 self.frame_gen = self.get_stream()
-            if not PY3:
-                frame = self.frame_gen.next()
-            else:
-                frame = self.frame_gen.__next__()
-            return frame
+            return six.next(self.frame_gen)
 
     def update_rotation(self, rotation):
         """

--- a/airtest/core/android/minitouch.py
+++ b/airtest/core/android/minitouch.py
@@ -1,18 +1,21 @@
 # -*- coding: utf-8 -*-
 import os
-import sys
 import re
-import time
 import socket
+import sys
 import threading
+import time
 import warnings
-from airtest.core.error import MinitouchError
+
+from six.moves import queue
+
 from airtest.core.android.constant import STFLIB
-from airtest.utils.compat import queue
-from airtest.utils.safesocket import SafeSocket
-from airtest.utils.nbsp import NonBlockingStreamReader
-from airtest.utils.snippet import reg_cleanup, get_std_encoding, on_method_ready, ready_method
 from airtest.utils.logger import get_logger
+from airtest.utils.nbsp import NonBlockingStreamReader
+from airtest.utils.safesocket import SafeSocket
+from airtest.utils.snippet import (get_std_encoding, on_method_ready,
+                                   ready_method, reg_cleanup)
+
 LOGGING = get_logger(__name__)
 
 

--- a/airtest/core/api.py
+++ b/airtest/core/api.py
@@ -4,11 +4,15 @@ This module contains the Airtest Core APIs.
 """
 import os
 import time
-from airtest.utils.compat import urlparse, parse_qsl
+
+from six.moves.urllib.parse import parse_qsl, urlparse
+
 from airtest.core.cv import Template, loop_find, try_log_screen
 from airtest.core.error import TargetNotFoundError
-from airtest.core.helper import G, set_logdir, logwrap, on_platform, import_device_cls, delay_after_operation
+from airtest.core.helper import (G, delay_after_operation, import_device_cls,
+                                 logwrap, on_platform)
 from airtest.core.settings import Settings as ST
+
 
 """
 Device Setup APIs

--- a/airtest/core/cv.py
+++ b/airtest/core/cv.py
@@ -12,9 +12,8 @@ from airtest.core.error import TargetNotFoundError
 from airtest.core.helper import G, logwrap, log_in_func
 from airtest.core.settings import Settings as ST
 from airtest.utils.transform import TargetPos
-from airtest.utils.compat import PY3
 from copy import deepcopy
-
+from six import PY3
 
 @logwrap
 def loop_find(query, timeout=ST.FIND_TIMEOUT, threshold=None, interval=0.5, intervalfunc=None):

--- a/airtest/core/ios/minicap.py
+++ b/airtest/core/ios/minicap.py
@@ -47,7 +47,7 @@ class MinicapIOS(object):
         s.connect(("localhost", self.port))
         t = s.recv(24)
         # minicap info
-        print struct.unpack("<2B5I2B", t)
+        print(struct.unpack("<2B5I2B", t))
 
         while True:
             # recv header, count frame_size

--- a/airtest/report/report.py
+++ b/airtest/report/report.py
@@ -7,7 +7,8 @@ import sys
 import shutil
 import jinja2
 from collections import defaultdict
-from airtest.utils.compat import decode_path, PY3
+from airtest.utils.compat import decode_path
+from six import PY3
 
 LOGDIR = "log"
 LOGFILE = "log.txt"

--- a/airtest/utils/apkparser/stringblock.py
+++ b/airtest/utils/apkparser/stringblock.py
@@ -16,8 +16,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Androguard.  If not, see <http://www.gnu.org/licenses/>.
 
+import six
 from .bytecode import SV
-from airtest.utils.compat import PY3
 
 
 class StringBlock:
@@ -81,11 +81,8 @@ class StringBlock:
 
         while length > 0:
             offset += 2
-            if PY3:
-                data += chr(self.getShort(self.m_strings, offset))
-            else:
-                # get the unicode character as the apk might contain non-ASCII label
-                data += unichr(self.getShort(self.m_strings, offset))
+            # get the unicode character as the apk might contain non-ASCII label
+            data += six.unichr(self.getShort(self.m_strings, offset))
 
             # FIXME
             if data[-1] == "&":
@@ -101,4 +98,3 @@ class StringBlock:
             return value & 0xFFFF
         else:
             return value >> 16
-

--- a/airtest/utils/compat.py
+++ b/airtest/utils/compat.py
@@ -1,34 +1,9 @@
-# coding: utf-8
-import six
 import sys
-
-# Useful for very coarse version differentiation.
-PY3 = sys.version_info[0] == 3
+from six import PY3
 
 if PY3:
-    from configparser import ConfigParser
-    from urllib.parse import unquote, urlparse, parse_qsl
-    import queue
-
-    text_type = str
-    str_class = str
-
-    def enforce_unicode(text):
-        return text
-
     def decode_path(path):
         return path
 else:
-    from ConfigParser import SafeConfigParser as ConfigParser
-    import Queue as queue
-    from urllib import unquote
-    from urlparse import urlparse, parse_qsl
-
-    text_type = unicode
-    str_class = basestring
-
-    def enforce_unicode(text):
-        return unicode(text)
-
     def decode_path(path):
         return path.decode(sys.getfilesystemencoding()) if path else path

--- a/airtest/utils/nbsp.py
+++ b/airtest/utils/nbsp.py
@@ -1,7 +1,7 @@
 # _*_ coding:UTF-8 _*_
 import time
 from threading import Thread, Event
-from .compat import queue
+from six.moves import queue
 from .logger import get_logger
 LOGGING = get_logger(__name__)
 

--- a/airtest/utils/snippet.py
+++ b/airtest/utils/snippet.py
@@ -1,8 +1,9 @@
 # _*_ coding:UTF-8 _*_
-import atexit
 import sys
+import threading
 from functools import wraps
-from .compat import str_class, queue
+from six import string_types
+from six.moves import queue
 
 
 def split_cmd(cmds):
@@ -16,12 +17,8 @@ def split_cmd(cmds):
         array commands
 
     """
-    if isinstance(cmds, str_class):
-        # cmds = shlex.split(cmds)  # disable auto removing \ on windows
-        cmds = cmds.split()
-    else:
-        cmds = list(cmds)
-    return cmds
+    # cmds = shlex.split(cmds)  # disable auto removing \ on windows
+    return cmds.split() if isinstance(cmds, string_types) else list(cmds)
 
 
 def get_std_encoding(stream):
@@ -36,7 +33,6 @@ def get_std_encoding(stream):
 
     """
     return getattr(stream, "encoding", None) or sys.getfilesystemencoding()
-
 
 
 CLEANUP_CALLS = queue.Queue()
@@ -68,9 +64,6 @@ def _cleanup():
 
 # atexit.register(_cleanup)
 
-import threading
-
-
 _shutdown = threading._shutdown
 
 
@@ -84,8 +77,6 @@ def exitfunc():
 # atexit exec after all thread exit, which needs to cooperate with daemon thread.
 # daemon thread is evil, which abruptly exit causing unexpected error
 threading._shutdown = exitfunc
-
-
 
 
 def on_method_ready(method_name):

--- a/playground/test_blackjack.air/test_blackjack.py
+++ b/playground/test_blackjack.air/test_blackjack.py
@@ -3,6 +3,8 @@
 __author__ = "刘欣"
 
 import os
+from time import sleep
+
 PWD = args.script
 PKG = "org.cocos2d.blackjack"
 APK = os.path.join(PWD, "blackjack-release-signed.apk")

--- a/tests/test_adb.py
+++ b/tests/test_adb.py
@@ -5,6 +5,7 @@ from types import GeneratorType
 import os
 import unittest
 import subprocess
+from six import text_type
 
 
 class TestADBWithoutDevice(unittest.TestCase):
@@ -38,7 +39,7 @@ class TestADBWithoutDevice(unittest.TestCase):
 
     def test_cmd(self):
         output = self.adb.cmd("devices", device=False)
-        self.assertIsInstance(output, unicode)
+        self.assertIsInstance(output, text_type)
 
         with self.assertRaises(AdbError):
             self.adb.cmd("wtf", device=False)
@@ -81,20 +82,20 @@ class TestADBWithDevice(unittest.TestCase):
     def test_raw_shell(self):
         output = self.adb.raw_shell("pwd")
         self.assertEqual(output.strip(), "/")
-        self.assertIsInstance(output, unicode)
+        self.assertIsInstance(output, text_type)
 
         self.assertIsInstance(self.adb.raw_shell("pwd", ensure_unicode=False), str)
 
     def test_shell(self):
         output = self.adb.shell("time")
-        self.assertIsInstance(output, unicode)
+        self.assertIsInstance(output, text_type)
 
         with self.assertRaises(AdbShellError):
             self.adb.shell("ls some_imposible_path")
 
     def test_getprop(self):
         output = self.adb.getprop("wifi.interface")
-        self.assertIsInstance(output, unicode)
+        self.assertIsInstance(output, text_type)
 
     def test_sdk_version(self):
         output = self.adb.sdk_version


### PR DESCRIPTION
Leverage the __six__ module to reduce __compat.py__ to just a single function while fixing several Python 3 issues.

__playground/test_blackjack.air/test_blackjack.py__ still has 14 undefined names:

$ __python3 -m flake8 . --count --select=E9,F82 --show-source --statistics__
```
./playground/test_blackjack.air/test_blackjack.py:8:7: F821 undefined name 'args'
PWD = args.script
      ^
./playground/test_blackjack.air/test_blackjack.py:11:15: F821 undefined name 'device'
if PKG not in device().list_app():
              ^
./playground/test_blackjack.air/test_blackjack.py:12:5: F821 undefined name 'install'
    install(APK)
    ^
./playground/test_blackjack.air/test_blackjack.py:13:1: F821 undefined name 'stop_app'
stop_app(PKG)
^
./playground/test_blackjack.air/test_blackjack.py:14:1: F821 undefined name 'wake'
wake()
^
./playground/test_blackjack.air/test_blackjack.py:15:1: F821 undefined name 'start_app'
start_app(PKG)
^
./playground/test_blackjack.air/test_blackjack.py:17:1: F821 undefined name 'touch'
touch(Template(r"tpl1499240443959.png", record_pos=(0.22, -0.165), resolution=(2560, 1536)))
^
./playground/test_blackjack.air/test_blackjack.py:17:7: F821 undefined name 'Template'
touch(Template(r"tpl1499240443959.png", record_pos=(0.22, -0.165), resolution=(2560, 1536)))
      ^
./playground/test_blackjack.air/test_blackjack.py:19:1: F821 undefined name 'assert_exists'
assert_exists(Template(r"tpl1499240472304.png", record_pos=(0.0, -0.094), resolution=(2560, 1536)), "请下注")
^
./playground/test_blackjack.air/test_blackjack.py:19:15: F821 undefined name 'Template'
assert_exists(Template(r"tpl1499240472304.png", record_pos=(0.0, -0.094), resolution=(2560, 1536)), "请下注")
              ^
./playground/test_blackjack.air/test_blackjack.py:22:5: F821 undefined name 'wait'
p = wait(Template(r"tpl1499240490986.png", record_pos=(-0.443, -0.273), resolution=(2560, 1536)))
    ^
./playground/test_blackjack.air/test_blackjack.py:22:10: F821 undefined name 'Template'
p = wait(Template(r"tpl1499240490986.png", record_pos=(-0.443, -0.273), resolution=(2560, 1536)))
         ^
./playground/test_blackjack.air/test_blackjack.py:24:1: F821 undefined name 'touch'
touch(p)
^
./playground/test_blackjack.air/test_blackjack.py:26:1: F821 undefined name 'stop_app'
stop_app(PKG)
^
14    F821 undefined name 'args'
```