### PR TITLE
from airtest.core.api import the undefined names

### DIFF
--- a/playground/test_blackjack.air/test_blackjack.py
+++ b/playground/test_blackjack.air/test_blackjack.py
@@ -20,6 +20,7 @@ touch(Template(r"tpl1499240443959.png", record_pos=(0.22, -0.165), resolution=(2
 
 assert_exists(Template(r"tpl1499240472304.png", record_pos=(0.0, -0.094), resolution=(2560, 1536)), "请下注")
 
+
 p = wait(Template(r"tpl1499240490986.png", record_pos=(-0.443, -0.273), resolution=(2560, 1536)))
 
 touch(p)

--- a/playground/test_blackjack.air/test_blackjack.py
+++ b/playground/test_blackjack.air/test_blackjack.py
@@ -4,8 +4,8 @@ __author__ = "刘欣"
 
 import os
 from time import sleep
-from airtest.core.api import (Template, assert_exists, device, install,
-                              start_app, stop_app, touch, wake)
+from airtest.core.api import (Template, args, assert_exists, device, install,
+                              start_app, stop_app, touch, wait, wake)
 
 PWD = args.script
 PKG = "org.cocos2d.blackjack"

--- a/playground/test_blackjack.air/test_blackjack.py
+++ b/playground/test_blackjack.air/test_blackjack.py
@@ -4,6 +4,8 @@ __author__ = "刘欣"
 
 import os
 from time import sleep
+from airtest.core.api import (Template, device, install,
+                              start_app, stop_app, touch, wake)
 
 PWD = args.script
 PKG = "org.cocos2d.blackjack"
@@ -17,7 +19,6 @@ sleep(2)
 touch(Template(r"tpl1499240443959.png", record_pos=(0.22, -0.165), resolution=(2560, 1536)))
 
 assert_exists(Template(r"tpl1499240472304.png", record_pos=(0.0, -0.094), resolution=(2560, 1536)), "请下注")
-
 
 p = wait(Template(r"tpl1499240490986.png", record_pos=(-0.443, -0.273), resolution=(2560, 1536)))
 

--- a/playground/test_blackjack.air/test_blackjack.py
+++ b/playground/test_blackjack.air/test_blackjack.py
@@ -4,7 +4,7 @@ __author__ = "刘欣"
 
 import os
 from time import sleep
-from airtest.core.api import (Template, device, install,
+from airtest.core.api import (Template, assert_exists, device, install,
                               start_app, stop_app, touch, wake)
 
 PWD = args.script


### PR DESCRIPTION
Should fix the flake8 tests.