### PR TITLE
坐标修改

### DIFF
--- a/airtest/core/android/android.py
+++ b/airtest/core/android/android.py
@@ -280,7 +280,7 @@ class Android(Device):
         
         for _ in range(times):
             if self.touch_method == TOUCH_METHOD.MINITOUCH:
-				pos = self._touch_point_by_orientation(pos)
+                pos = self._touch_point_by_orientation(pos)
                 self.minitouch.touch(pos, duration=duration)
             else:
                 self.adb.touch(pos)

--- a/airtest/core/android/android.py
+++ b/airtest/core/android/android.py
@@ -277,9 +277,10 @@ class Android(Device):
             None
 
         """
-        pos = self._touch_point_by_orientation(pos)
+        
         for _ in range(times):
             if self.touch_method == TOUCH_METHOD.MINITOUCH:
+				pos = self._touch_point_by_orientation(pos)
                 self.minitouch.touch(pos, duration=duration)
             else:
                 self.adb.touch(pos)


### PR DESCRIPTION
一、android.py
1，touch
    采用adb触摸屏幕，不需要坐标转换，只有用MINITOUCH才需要；

二，adb.py
1，raw_shell
    out = self.cmd(cmds, ensure_unicode=False)中将ensure_unicode设为FALSE，
    在cmd函数中执行re.search(DeviceConnectionError.DEVICE_CONNECTION_ERROR, stderr)会报编码错误；
    将模拟点击权限取消会报这个错误；

