### PR TITLE
当adb设备连接失败时，会导致out of index

### DIFF
--- a/airtest/core/android/android.py
+++ b/airtest/core/android/android.py
@@ -29,6 +29,8 @@ class Android(Device):
                  ori_method=ORI_METHOD.MINICAP,
                  ):
         super(Android, self).__init__()
+        if not ADB().devices(state="device"):
+            raise Exception("ADB devices not found")
         self.serialno = serialno or ADB().devices(state="device")[0][0]
         self.cap_method = cap_method.upper()
         self.touch_method = touch_method.upper()


### PR DESCRIPTION
当adb设备连接失败时，ADB().devices(state="device")返回空列表，不能直接去索引值。
应该加一个判断。