### PR TITLE
modify connection error pattern. When use adb on wifi, this pattern w…

### DIFF
--- a/airtest/core/error.py
+++ b/airtest/core/error.py
@@ -59,7 +59,7 @@ class DeviceConnectionError(BaseError):
     """
         device connection error
     """
-    DEVICE_CONNECTION_ERROR = r"error:\s*((device \'\w+\' not found)|(cannot connect to daemon at [\w\:\s\.]+ Connection timed out))"
+    DEVICE_CONNECTION_ERROR = r"error:\s*((device \'\S+\' not found)|(cannot connect to daemon at [\w\:\s\.]+ Connection timed out))"
     pass
 
 


### PR DESCRIPTION
当通过wifi连接adb时， 连接失败错误是这样的，“error: device '182.178.11.01' not found”， 显示的是ip地址而不是adb 序列号。当前的正则用w+无法匹配"."。
您看是修改成这样，将两种情况归为一种。还是通过'|'分别来匹配两种情况。