### PR TITLE
Fix report module didn't work when there is using(xxx.air)

### DIFF
--- a/airtest/report/report.py
+++ b/airtest/report/report.py
@@ -195,7 +195,8 @@ class LogToHtml(object):
                     if not os.path.isfile(os.path.join(self.script_root, image_path)):
                         shutil.copy(value['_filepath'], self.script_root)
                 arg["image"] = image_path
-                crop_img = imread(os.path.join(self.script_root, str(value['filename'])))
+                crop_img = imread(image_path)  # using(xxx.air) 导致图片可能不在script_root
+                # crop_img = imread(os.path.join(self.script_root, str(value['filename'])))
                 arg["resolution"] = get_resolution(crop_img)
         return code
 


### PR DESCRIPTION
当script里使用了using(xxx.air)引入其他air模块，生产的结果log.txt中的图片无法通过script_root 进行定位，进而导致report失败。