### PR TITLE
Update is_locked method

### DIFF
--- a/airtest/core/android/adb.py
+++ b/airtest/core/android/adb.py
@@ -1052,11 +1052,8 @@ class ADB(object):
         Returns:
             True or False whether the screen is locked or not
 
-        Notes:
-            Does not work on Xiaomi 2S
-
         """
-        lockScreenRE = re.compile('mShowingLockscreen=(true|false)')
+        lockScreenRE = re.compile('(?:mShowingLockscreen|isStatusBarKeyguard)=(true|false)')
         m = lockScreenRE.search(self.shell('dumpsys window policy'))
         if not m:
             raise AirtestError("Couldn't determine screen lock state")


### PR DESCRIPTION
修复Xiaomi 2S等手机不能使用is_locked判断是否解锁屏幕的问题，并移除相关注释

PS: 在Xiaomi 2S手机上测试通过