### PR TITLE
update log_template.html css

### DIFF
--- a/airtest/report/log_template.html
+++ b/airtest/report/log_template.html
@@ -64,6 +64,8 @@
 
     div.screen_holder img {
       /*max-height: 600px;*/
+      min-width:20px;
+      min-height:20px;
     }
 
     img.crop_image {


### PR DESCRIPTION
set min rect for "div.screen_holder img" . It will be able to fix screenshots that cannot be displayed on firefox
https://testerhome.com/topics/18832