### PR TITLE
remove repeat setattr in snippet.py

### DIFF
--- a/airtest/utils/snippet.py
+++ b/airtest/utils/snippet.py
@@ -102,7 +102,6 @@ def on_method_ready(method_name):
             if not getattr(inst, key, None):
                 method = getattr(inst, method_name)
                 method()
-                setattr(inst, key, True)
             return func(inst, *args, **kwargs)
         return ready_func
     return wrapper


### PR DESCRIPTION
airtest\utils\snippet.py中的on_method_ready方法中的setattr(inst, key, True)会设置实例属性，但ready_method方法中的setattr(inst, key, True)也会设置实例属性，因此会设置2次同样的属性，虽然运行没有问题，但有冗余，因此移除on_method_ready方法中的setattr(inst, key, True).