### PR TITLE
兼容个别版本android手机执行minicap CMD后出现Warning提示

### DIFF
--- a/airtest/core/android/minicap.py
+++ b/airtest/core/android/minicap.py
@@ -150,6 +150,8 @@ class Minicap(object):
             display_info = self.adb.shell("{0} -d {1} -i".format(self.CMD, self.display_id))
         else:
             display_info = self.adb.shell("%s -i" % self.CMD)
+        match = re.compile(r'({.*})', re.DOTALL).search(display_info)
+        display_info = match.group(0) if match else display_info
         display_info = json.loads(display_info)
         display_info["orientation"] = display_info["rotation"] / 90
         # 针对调整过手机分辨率的情况


### PR DESCRIPTION
个别版本android手机执行minicap CMD后出现Warning提示，到json.loads出现异常
![图片](https://user-images.githubusercontent.com/10250772/71511694-307b9180-28ce-11ea-9ca0-ab8501bd4e3e.png)
