### PR TITLE
Fix bug  https://github.com/AirtestProject/Airtest/issues/711

### DIFF
--- a/airtest/core/android/adb.py
+++ b/airtest/core/android/adb.py
@@ -1059,11 +1059,18 @@ class ADB(object):
             True or False whether the screen is turned on or off
 
         """
-        screenOnRE = re.compile('mScreenOnFully=(true|false)')
-        m = screenOnRE.search(self.shell('dumpsys window policy'))
-        if m:
-            return (m.group(1) == 'true')
-        raise AirtestError("Couldn't determine screen ON state")
+        try:
+            screenOnRE = re.compile('mScreenOnFully=(true|false)')
+            m = screenOnRE.search(self.shell('dumpsys window policy'))
+            if m:
+                return (m.group(1) == 'true')
+            raise AirtestError("Couldn't determine screen ON state")
+        except Exception:
+            screenOnRE = re.compile('screenState=(SCREEN_STATE_ON|SCREEN_STATE_OFF)')
+            m = screenOnRE.search(self.shell('dumpsys window policy'))
+            if m:
+                return (m.group(1) == 'SCREEN_STATE_ON')
+            raise AirtestError("Couldn't determine screen ON state")
 
     def is_locked(self):
         """


### PR DESCRIPTION
fix :【安卓10 ,miui 11】 ,检测不了屏幕是否锁定 "Couldn't determine screen ON ” #711

https://github.com/AirtestProject/Airtest/issues/711