### PR TITLE
fix bug：兼容 安卓10，miui11 (is_screenon()，is_locked())

### DIFF
--- a/airtest/core/android/adb.py
+++ b/airtest/core/android/adb.py
@@ -1059,11 +1059,18 @@ class ADB(object):
             True or False whether the screen is turned on or off
 
         """
-        screenOnRE = re.compile('mScreenOnFully=(true|false)')
-        m = screenOnRE.search(self.shell('dumpsys window policy'))
-        if m:
-            return (m.group(1) == 'true')
-        raise AirtestError("Couldn't determine screen ON state")
+        try:
+            screenOnRE = re.compile('mScreenOnFully=(true|false)')
+            m = screenOnRE.search(self.shell('dumpsys window policy'))
+            if m:
+                return (m.group(1) == 'true')
+            raise AirtestError("Couldn't determine screen ON state")
+        except Exception:
+            screenOnRE = re.compile('screenState=(SCREEN_STATE_ON|SCREEN_STATE_OFF)')
+            m = screenOnRE.search(self.shell('dumpsys window policy'))
+            if m:
+                return (m.group(1) == 'SCREEN_STATE_ON')
+            raise AirtestError("Couldn't determine screen ON state")
 
     def is_locked(self):
         """
@@ -1076,7 +1083,7 @@ class ADB(object):
             True or False whether the screen is locked or not
 
         """
-        lockScreenRE = re.compile('(?:mShowingLockscreen|isStatusBarKeyguard)=(true|false)')
+        lockScreenRE = re.compile('(?:mShowingLockscreen|isStatusBarKeyguard|showing)=(true|false)')
         m = lockScreenRE.search(self.shell('dumpsys window policy'))
         if not m:
             raise AirtestError("Couldn't determine screen lock state")


### PR DESCRIPTION
Fix bug https://github.com/AirtestProject/Airtest/issues/711

【安卓10 ,miui 11】 ,检测不了屏幕是否锁定 "Couldn't determine screen ON “

设备：小米8 miui11 android 10
1.is_screenon()
2.is_locked()

以上2个api，检测屏幕是否锁定时报错："Couldn't determine screen ON “