### PR TITLE
1.2.2紧急修改

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ htmlcov/
 cover/
 
 .idea/
+.vscode/
 .DS_Store
 env/
 screencapture.bmp

--- a/airtest/core/android/adb.py
+++ b/airtest/core/android/adb.py
@@ -656,9 +656,17 @@ class ADB(object):
         print(out)
 
         if not replace:
-            self.shell(['pm', 'install', device_path])
+            install_cmd = ['pm', 'install', device_path]
         else:
-            self.shell(['pm', 'install', '-r', device_path])
+            install_cmd = ['pm', 'install', '-r', device_path]
+
+        try:
+            self.shell(install_cmd)
+        except:
+            raise
+        finally:
+            # delete apk file
+            self.shell("rm " + device_path)
 
     def uninstall_app(self, package):
         """

--- a/airtest/core/android/adb.py
+++ b/airtest/core/android/adb.py
@@ -882,6 +882,7 @@ class ADB(object):
 
         """
         display_info = self.getPhysicalDisplayInfo()
+        display_info = self.update_cur_display(display_info)
         orientation = self.getDisplayOrientation()
         max_x, max_y = self.getMaxXY()
         display_info.update({
@@ -1038,6 +1039,32 @@ class ADB(object):
         # We couldn't obtain the orientation
         warnings.warn("Could not obtain the orientation, return 0")
         return 0
+
+    def update_cur_display(self, display_info):
+        """
+        Some phones support resolution modification, try to get the modified resolution from dumpsys
+        adb shell dumpsys window displays | find "cur="
+
+        Args:
+            display_info: the return of self.getPhysicalDisplayInfo()
+
+        Returns:
+            display_info
+
+        """
+        # adb shell dumpsys window displays | find "init="
+        # 上面的命令行在dumpsys window里查找init=widthxheight，得到的结果是物理分辨率，且部分型号手机不止一个结果
+        # 如果改为读取 cur=widthxheight 的数据，得到的是修改过分辨率手机的结果（例如三星S8）
+        actual = self.shell("dumpsys window displays")
+        arr = re.findall(r'cur=(\d+)x(\d+)', actual)
+        if len(arr) > 0:
+            # 强制设定宽度width为更小的数字、height为更大的数字，避免因为各手机厂商返回结果的顺序不同导致问题
+            # Set the width to a smaller number and the height to a larger number
+            width, height = min(list(map(int, arr[0]))), max(list(map(int, arr[0])))
+            display_info['physical_width'] = display_info['width']
+            display_info['physical_height'] = display_info['height']
+            display_info['width'], display_info['height'] = width, height
+        return display_info
 
     def get_top_activity(self):
         """

--- a/airtest/core/android/android.py
+++ b/airtest/core/android/android.py
@@ -78,7 +78,7 @@ class Android(Device):
         self._touch_proxy = TouchProxy.auto_setup(self.adb,
                                                   default_method=self._touch_method,
                                                   ori_transformer=self._touch_point_by_orientation,
-                                                  ori_function=self.get_display_info,
+                                                  size_info=self.display_info,
                                                   input_event=self.input_event)
         return self._touch_proxy
 
@@ -722,6 +722,8 @@ class Android(Device):
 
         """
         self.rotation_watcher.get_ready()
+        if self._screen_proxy:
+            return self.screen_proxy.get_display_info()
         return self.adb.get_display_info()
 
     def get_current_resolution(self):

--- a/airtest/core/android/cap_methods/base_cap.py
+++ b/airtest/core/android/cap_methods/base_cap.py
@@ -47,3 +47,6 @@ class BaseCap(object):
             traceback.print_exc()
             return None
         return screen
+
+    def get_display_info(self):
+        return self.adb.get_display_info()

--- a/airtest/core/android/cap_methods/minicap.py
+++ b/airtest/core/android/cap_methods/minicap.py
@@ -175,8 +175,8 @@ class Minicap(BaseCap):
             display_info['physical_height'] = display_info['height']
             # 强制设定宽度width为更小的数字、height为更大的数字，避免因为各手机厂商返回结果的顺序不同导致问题
             # Set the width to a smaller number and the height to a larger number
-            display_info['width'] = int(min(arr[0]))
-            display_info['height'] = int(max(arr[0]))
+            display_info['width'] = min(list(map(int, arr[0])))
+            display_info['height'] = max(list(map(int, arr[0])))
         return display_info
 
     @on_method_ready('install_or_upgrade')

--- a/airtest/core/android/cap_methods/minicap.py
+++ b/airtest/core/android/cap_methods/minicap.py
@@ -165,18 +165,7 @@ class Minicap(BaseCap):
         display_info = match.group(0) if match else display_info
         display_info = json.loads(display_info)
         display_info["orientation"] = display_info["rotation"] / 90
-        # adb shell dumpsys window displays | find "init="
-        # 在dumpsys window里找init=widthxheight，得到的结果是物理分辨率，且部分型号手机不止一个结果
-        # 如果改为读取 cur=widthxheight 的数据，得到的是修改过分辨率手机的结果（例如三星S8）
-        actual = self.adb.shell("dumpsys window displays")
-        arr = re.findall(r'cur=(\d+)x(\d+)', actual)
-        if len(arr) > 0:
-            display_info['physical_width'] = display_info['width']
-            display_info['physical_height'] = display_info['height']
-            # 强制设定宽度width为更小的数字、height为更大的数字，避免因为各手机厂商返回结果的顺序不同导致问题
-            # Set the width to a smaller number and the height to a larger number
-            display_info['width'] = min(list(map(int, arr[0])))
-            display_info['height'] = max(list(map(int, arr[0])))
+        display_info = self.adb.update_cur_display(display_info)
         return display_info
 
     @on_method_ready('install_or_upgrade')

--- a/airtest/core/android/touch_methods/base_touch.py
+++ b/airtest/core/android/touch_methods/base_touch.py
@@ -15,7 +15,7 @@ class BaseTouch(object):
     A super class for Minitouch or Maxtouch
     """
 
-    def __init__(self, adb, backend=False, ori_function=None, input_event=None, *args, **kwargs):
+    def __init__(self, adb, backend=False, size_info=None, input_event=None, *args, **kwargs):
         self.adb = adb
         self.backend = backend
         self.server_proc = None
@@ -23,7 +23,7 @@ class BaseTouch(object):
         self.size_info = None
         self.input_event = input_event
         self.handle = None
-        self.ori_function = ori_function if callable(ori_function) else self.adb.getPhysicalDisplayInfo
+        self.size_info = size_info or self.adb.get_display_info()
         self.default_pressure = 50
         self.path_in_android = ""
         reg_cleanup(self.teardown)
@@ -38,7 +38,6 @@ class BaseTouch(object):
 
         """
         self.install()
-        self.size_info = self.ori_function()
         self.setup_server()
         if self.backend:
             self.setup_client_backend()

--- a/airtest/core/android/touch_methods/maxtouch.py
+++ b/airtest/core/android/touch_methods/maxtouch.py
@@ -13,8 +13,8 @@ LOGGING = get_logger(__name__)
 
 class Maxtouch(BaseTouch):
 
-    def __init__(self, adb, backend=False, ori_function=None, input_event=None):
-        super(Maxtouch, self).__init__(adb, backend, ori_function, input_event)
+    def __init__(self, adb, backend=False, size_info=None, input_event=None):
+        super(Maxtouch, self).__init__(adb, backend, size_info, input_event)
         self.default_pressure = 0.5
         self.path_in_android = "/data/local/tmp/maxpresent.jar"
 

--- a/airtest/core/android/touch_methods/minitouch.py
+++ b/airtest/core/android/touch_methods/minitouch.py
@@ -17,8 +17,8 @@ LOGGING = get_logger(__name__)
 
 class Minitouch(BaseTouch):
 
-    def __init__(self, adb, backend=False, ori_function=None, input_event=None):
-        super(Minitouch, self).__init__(adb, backend, ori_function, input_event)
+    def __init__(self, adb, backend=False, size_info=None, input_event=None):
+        super(Minitouch, self).__init__(adb, backend, size_info, input_event)
         self.default_pressure = 50
         self.path_in_android = "/data/local/tmp/minitouch"
         self.max_x, self.max_y = None, None

--- a/airtest/core/android/touch_methods/touch_proxy.py
+++ b/airtest/core/android/touch_methods/touch_proxy.py
@@ -41,14 +41,14 @@ class TouchProxy(object):
             return True
 
     @classmethod
-    def auto_setup(cls, adb, default_method=None, ori_transformer=None, ori_function=None, input_event=None):
+    def auto_setup(cls, adb, default_method=None, ori_transformer=None, size_info=None, input_event=None):
         """
 
         Args:
             adb: :py:mod:`airtest.core.android.adb.ADB`
             default_method: The default click method, such as "MINITOUCH"
             ori_transformer: dev._touch_point_by_orientation
-            ori_function: dev.get_display_info
+            size_info: the result of dev.get_display_info()
             input_event: dev.input_event
             *args:
             **kwargs:
@@ -62,7 +62,7 @@ class TouchProxy(object):
 
         """
         if default_method and default_method in cls.TOUCH_METHODS:
-            touch_method = cls.TOUCH_METHODS[default_method].METHOD_CLASS(adb, ori_function=ori_function,
+            touch_method = cls.TOUCH_METHODS[default_method].METHOD_CLASS(adb, size_info=size_info,
                                                                           input_event=input_event)
             impl = cls.TOUCH_METHODS[default_method](touch_method, ori_transformer)
             if cls.check_touch(impl):
@@ -71,7 +71,7 @@ class TouchProxy(object):
         for name, touch_impl in cls.TOUCH_METHODS.items():
             if default_method == name:
                 continue
-            touch_method = touch_impl.METHOD_CLASS(adb, ori_function=ori_function, input_event=input_event)
+            touch_method = touch_impl.METHOD_CLASS(adb, size_info=size_info, input_event=input_event)
             impl = touch_impl(touch_method, ori_transformer)
             if cls.check_touch(impl):
                 return TouchProxy(impl)

--- a/airtest/utils/version.py
+++ b/airtest/utils/version.py
@@ -1,4 +1,4 @@
-__version__ = "1.2.1"
+__version__ = "1.2.2"
 
 import os
 import sys

--- a/tests/test_adb.py
+++ b/tests/test_adb.py
@@ -178,6 +178,11 @@ class TestADBWithDevice(unittest.TestCase):
         self.adb.pm_install(APK)
         self.assertIn(PKG, self.adb.list_app())
 
+        # 安装完毕后，验证apk文件是否已删除
+        tmpdir = "/data/local/tmp"
+        tmp_files = self.adb.shell("ls " + tmpdir)
+        self.assertNotIn(os.path.basename(APK), tmp_files, "The apk file in /data/local/tmp is not deleted!")
+
         self.adb.pm_uninstall(PKG)
         self.assertNotIn(PKG, self.adb.list_app())
 

--- a/tests/test_touch_proxy.py
+++ b/tests/test_touch_proxy.py
@@ -15,14 +15,14 @@ class TestTouchProxy(unittest.TestCase):
     def test_auto_setup(self):
         touch_proxy = TouchProxy.auto_setup(self.dev.adb,
                                             ori_transformer=self.dev._touch_point_by_orientation,
-                                            ori_function=None,
+                                            size_info=None,
                                             input_event=None)
         touch_proxy.touch((100, 100))
 
         touch_proxy = TouchProxy.auto_setup(self.dev.adb,
                                             default_method="MINITOUCH",
                                             ori_transformer=self.dev._touch_point_by_orientation,
-                                            ori_function=self.dev.get_display_info,
+                                            size_info=self.dev.display_info,
                                             input_event=self.dev.input_event)
         touch_proxy.touch((100, 100))
 


### PR DESCRIPTION
- 修复一个因为字段类型导致部分型号手机横竖屏不能正确获取的问题
- 在`adb.pm_install`接口中增加安装完毕后自动删除apk包的功能，避免调用完之后没清理，残留大量apk包的问题
- 更新了相关的testcase

补充修复一个问题：

部分型号的手机上，会有一个厂商额外设置的分辨率，例如三星和华为的部分机型，可以调节分辨率
之前的airtest是在minicap里调用`get_display_info`来获取分辨率的，能够获取到当前的真实分辨率，如果是用`adb.get_display_info`，只能获取到设备的物理分辨率（即手机最大的那个屏幕尺寸）
现在统一改动了`adb.get_display_info`可以获取到真实分辨率，这样这个尺寸信息能够提供给其他屏幕截图方法使用，比如javacap也能用到正确的分辨率信息了。
然后点击的时候，之前也会使用到`ori_function=get_display_info()`的参数，但实际上这个对`get_display_info`的调用似乎只是需要获取到当前屏幕尺寸，因此全部改成直接拿`device.display_info`，然后后续观察一下效果。

以前这个问题没有暴露出来，是因为即使用了Javacap来截图，也会尝试初始化minicap来获取分辨率，一般三星和华为都可以正确初始化，因此没遇到什么问题。但实际上如果选择了javacap，是不需要额外初始化一次minicap的，现在去掉了这个多余的初始化之后，反而导致分辨率信息可能会获取错误。虽然只需要用户把手机分辨率设置成最大也可以解决问题，但是现在还是尝试修改一下，看看会不会效果更好一些。