### PR TITLE
update:the old name will be removed in Jinja 3.1.

### DIFF
--- a/airtest/report/report.py
+++ b/airtest/report/report.py
@@ -12,7 +12,7 @@ import jinja2
 import traceback
 from copy import deepcopy
 from datetime import datetime
-from jinja2 import evalcontextfilter, Markup, escape
+from jinja2 import pass_eval_context, Markup, escape
 from airtest.aircv import imread, get_resolution
 from airtest.core.settings import Settings as ST
 from airtest.aircv.utils import compress_image
@@ -32,7 +32,7 @@ STATIC_DIR = os.path.dirname(__file__)
 _paragraph_re = re.compile(r'(?:\r\n|\r|\n){2,}')
 
 
-@evalcontextfilter
+@pass_eval_context
 def nl2br(eval_ctx, value):
     result = u'\n\n'.join(u'<p>%s</p>' % p.replace('\n', '<br>\n')
                           for p in _paragraph_re.split(escape(value)))


### PR DESCRIPTION
'evalcontextfilter' is renamed to 'pass_eval_context', the old name will be removed in Jinja 3.1.