### PR TITLE
v1.2.3

### DIFF
--- a/airtest/core/android/adb.py
+++ b/airtest/core/android/adb.py
@@ -962,7 +962,7 @@ class ADB(object):
         wm_size = re.search(r'(?P<width>\d+)x(?P<height>\d+)\s*$', self.raw_shell('wm size'))
         if wm_size:
             displayInfo = dict((k, int(v)) for k, v in wm_size.groupdict().items())
-            displayInfo['density'] = self._getDisplayDensity(None, strip=True)
+            displayInfo['density'] = self._getDisplayDensity(strip=True)
             return displayInfo
 
         phyDispRE = re.compile('.*PhysicalDisplayInfo{(?P<width>\d+) x (?P<height>\d+), .*, density (?P<density>[\d.]+).*')
@@ -985,11 +985,10 @@ class ADB(object):
         if not m:
             m = dispWHRE.search(out, 0)
         if m:
-            displayInfo = {}
             for prop in ['width', 'height']:
                 displayInfo[prop] = int(m.group(prop))
             for prop in ['density']:
-                d = self._getDisplayDensity(None, strip=True)
+                d = self._getDisplayDensity(strip=True)
                 if d:
                     displayInfo[prop] = d
                 else:
@@ -1001,21 +1000,19 @@ class ADB(object):
         phyDispRE = re.compile('Physical size: (?P<width>\d+)x(?P<height>\d+).*Physical density: (?P<density>\d+)', re.S)
         m = phyDispRE.search(self.raw_shell('wm size; wm density'))
         if m:
-            displayInfo = {}
             for prop in ['width', 'height']:
                 displayInfo[prop] = int(m.group(prop))
             for prop in ['density']:
                 displayInfo[prop] = float(m.group(prop))
             return displayInfo
 
-        return {}
+        return displayInfo
 
-    def _getDisplayDensity(self, key, strip=True):
+    def _getDisplayDensity(self, strip=True):
         """
         Get display density
 
         Args:
-            key:
             strip: strip the output
 
         Returns:

--- a/airtest/core/android/adb.py
+++ b/airtest/core/android/adb.py
@@ -957,11 +957,18 @@ class ADB(object):
             physical display info for dimension and density
 
         """
+        # use adb shell wm size
+        displayInfo = {}
+        wm_size = re.search(r'(?P<width>\d+)x(?P<height>\d+)\s*$', self.raw_shell('wm size'))
+        if wm_size:
+            displayInfo = dict((k, int(v)) for k, v in wm_size.groupdict().items())
+            displayInfo['density'] = self._getDisplayDensity(None, strip=True)
+            return displayInfo
+
         phyDispRE = re.compile('.*PhysicalDisplayInfo{(?P<width>\d+) x (?P<height>\d+), .*, density (?P<density>[\d.]+).*')
         out = self.raw_shell('dumpsys display')
         m = phyDispRE.search(out)
         if m:
-            displayInfo = {}
             for prop in ['width', 'height']:
                 displayInfo[prop] = int(m.group(prop))
             for prop in ['density']:

--- a/airtest/core/android/adb.py
+++ b/airtest/core/android/adb.py
@@ -835,7 +835,11 @@ class ADB(object):
         # After remove_forward() is successful, self._forward_local_using will be changed, so it needs to be copied
         forward_local_list = copy(self._forward_local_using)
         for local in forward_local_list:
-            self.remove_forward(local)
+            try:
+                self.remove_forward(local)
+            except DeviceConnectionError:
+                # 如果手机已经被拔出，可以忽略
+                pass
 
     @property
     def line_breaker(self):
@@ -890,7 +894,6 @@ class ADB(object):
 
         """
         display_info = self.getPhysicalDisplayInfo()
-        display_info = self.update_cur_display(display_info)
         orientation = self.getDisplayOrientation()
         max_x, max_y = self.getMaxXY()
         display_info.update({
@@ -1052,6 +1055,20 @@ class ADB(object):
         """
         Some phones support resolution modification, try to get the modified resolution from dumpsys
         adb shell dumpsys window displays | find "cur="
+
+        本方法虽然可以更好地获取到部分修改过分辨率的手机信息
+        但是会因为cur=(\d+)x(\d+)的数值在不同设备上width和height的顺序可能不同，导致横竖屏识别出现问题
+        airtest不再使用本方法作为通用的屏幕尺寸获取方法，但依然可用于部分设备获取当前被修改过的分辨率
+
+        Examples:
+
+            >>> # 部分三星和华为设备，若分辨率没有指定为最高，可能会导致点击偏移，可以用这个方式强制修改：
+            >>> # For some Samsung and Huawei devices, if the resolution is not specified as the highest,
+            >>> # it may cause click offset, which can be modified in this way:
+            >>> dev = device()
+            >>> info = dev.display_info
+            >>> info2 = dev.adb.update_cur_display(info)
+            >>> dev.display_info.update(info2)
 
         Args:
             display_info: the return of self.getPhysicalDisplayInfo()

--- a/airtest/core/android/android.py
+++ b/airtest/core/android/android.py
@@ -161,7 +161,8 @@ class Android(Device):
             return self._screen_proxy
         self._screen_proxy = ScreenProxy.auto_setup(self.adb, default_method=self._cap_method,
                                                     rotation_watcher=self.rotation_watcher,
-                                                    display_id=self.display_id)
+                                                    display_id=self.display_id,
+                                                    ori_function=lambda: self.display_info)
         return self._screen_proxy
 
     @screen_proxy.setter
@@ -722,8 +723,6 @@ class Android(Device):
 
         """
         self.rotation_watcher.get_ready()
-        if self._screen_proxy:
-            return self.screen_proxy.get_display_info()
         return self.adb.get_display_info()
 
     def get_current_resolution(self):

--- a/airtest/core/android/cap_methods/base_cap.py
+++ b/airtest/core/android/cap_methods/base_cap.py
@@ -47,6 +47,3 @@ class BaseCap(object):
             traceback.print_exc()
             return None
         return screen
-
-    def get_display_info(self):
-        return self.adb.get_display_info()

--- a/airtest/core/android/cap_methods/minicap.py
+++ b/airtest/core/android/cap_methods/minicap.py
@@ -146,29 +146,6 @@ class Minicap(BaseCap):
         LOGGING.info("minicap installation finished")
 
     @on_method_ready('install_or_upgrade')
-    def get_display_info(self):
-        """
-        Get display info by minicap
-
-        Warnings:
-            It might segfault, the preferred way is to get the information from adb commands
-
-        Returns:
-            display information
-
-        """
-        if self.display_id:
-            display_info = self.adb.shell("{0} -d {1} -i".format(self.CMD, self.display_id))
-        else:
-            display_info = self.adb.shell("%s -i" % self.CMD)
-        match = re.compile(r'({.*})', re.DOTALL).search(display_info)
-        display_info = match.group(0) if match else display_info
-        display_info = json.loads(display_info)
-        display_info["orientation"] = display_info["rotation"] / 90
-        display_info = self.adb.update_cur_display(display_info)
-        return display_info
-
-    @on_method_ready('install_or_upgrade')
     def get_frame(self, projection=None):
         """
         Get the single frame from minicap -s, this method slower than `get_frames`

--- a/airtest/core/android/cap_methods/minicap.py
+++ b/airtest/core/android/cap_methods/minicap.py
@@ -1,7 +1,7 @@
 ﻿# -*- coding: utf-8 -*-
 import os
 import re
-import json
+import traceback
 import struct
 import threading
 import six
@@ -41,7 +41,7 @@ class Minicap(BaseCap):
     RECVTIMEOUT = None
     CMD = "LD_LIBRARY_PATH=/data/local/tmp /data/local/tmp/minicap"
 
-    def __init__(self, adb, projection=None, rotation_watcher=None, display_id=None):
+    def __init__(self, adb, projection=None, rotation_watcher=None, display_id=None, ori_function=None):
         """
         :param adb: adb instance of android device
         :param projection: projection, default is None. If `None`, physical display size is used
@@ -49,7 +49,7 @@ class Minicap(BaseCap):
         super(Minicap, self).__init__(adb=adb)
         self.projection = projection
         self.display_id = display_id
-        self.ori_function = self.get_display_info
+        self.ori_function = ori_function or self.adb.get_display_info
         self.frame_gen = None
         self.stream_lock = threading.Lock()
         self.quirk_flag = 0

--- a/airtest/core/android/rotation.py
+++ b/airtest/core/android/rotation.py
@@ -129,8 +129,8 @@ class RotationWatcher(object):
 
                 ori = int(int(line) / 90)
                 return ori
-            # 每隔2秒读取一次
-            time.sleep(2)
+            # 每隔1秒读取一次
+            time.sleep(1)
 
         def _refresh_by_adb():
             ori = self.adb.getDisplayOrientation()

--- a/airtest/utils/version.py
+++ b/airtest/utils/version.py
@@ -1,4 +1,4 @@
-__version__ = "1.2.2"
+__version__ = "1.2.3"
 
 import os
 import sys

--- a/tests/test_screen_proxy.py
+++ b/tests/test_screen_proxy.py
@@ -20,7 +20,8 @@ class TestScreenProxy(unittest.TestCase):
         # 测试默认的初始化
         screen_proxy = ScreenProxy.auto_setup(self.dev.adb,
                                               rotation_watcher=self.dev.rotation_watcher,
-                                              display_id=self.dev.display_id)
+                                              display_id=self.dev.display_id,
+                                              ori_function=lambda: self.dev.display_info)
         self.assertIsNotNone(screen_proxy)
         screen_proxy.teardown_stream()
 


### PR DESCRIPTION
统一使用getPhysicalDisplayInfo()来获取手机尺寸信息，不再使用minicap或者dumpsys window displays获取，避免部分设备的横竖屏显示错误
因为每个设备的尺寸信息，在使用`dumpsys window displays`的`cur=`拿到的长宽顺序可能不一样，因此统一改成用adb获取手机的物理分辨率尺寸。
这样改动能较好地兼容模拟器、特殊设备（车机等）、几乎绝大多数型号的手机。
造成的可能后果是，例如三星和华为的部分手机型号，必须要将手机分辨率开到最大，才能正确显示画面，否则可能会出现点击偏移的问题。