### PR TITLE
add a setting that allows the user to specify snapshot mode in windows

### DIFF
--- a/airtest/core/settings.py
+++ b/airtest/core/settings.py
@@ -26,3 +26,5 @@ class Settings(object):
     # Image compression size, e.g. 1200, means that the size of the screenshot does not exceed 1200*1200
     IMAGE_MAXSIZE = os.environ.get("IMAGE_MAXSIZE", None)
     SAVE_IMAGE = True
+    #WIN_SNAPSHOT_MODE can be 'auto','derict','cutout' 
+    WIN_SNAPSHOT_MODE='auto'

--- a/airtest/core/win/win.py
+++ b/airtest/core/win/win.py
@@ -15,6 +15,7 @@ from pywinauto.win32functions import SetForegroundWindow, GetSystemMetrics
 
 from airtest.core.win.ctypesinput import key_press, key_release
 from airtest.core.win.screen import screenshot
+from airtest.core.settings import Settings as ST
 
 from airtest import aircv
 from airtest.core.device import Device
@@ -112,7 +113,7 @@ class Windows(Device):
             display the screenshot
 
         """
-        if self.handle:
+        if self.handle and ST.WIN_SNAPSHOT_MODE!='cutout':
             screen = screenshot(filename, self.handle)
         else:
             screen = screenshot(filename)


### PR DESCRIPTION
fixed #981 
增加自定义选项，可以自行指定win平台下的截图方式（在可用的情况下）