### PR TITLE
V1.2.5

### DIFF
--- a/airtest/aircv/multiscale_template_matching.py
+++ b/airtest/aircv/multiscale_template_matching.py
@@ -117,11 +117,13 @@ class MultiScaleTemplateMatching(object):
         w, h = int((w/sr)), int((h/sr))
         return max_loc, w, h
 
-    def multi_scale_search(self, org_src, org_templ, templ_min=10, src_max=800, ratio_min=0.01, ratio_max=0.99, step=0.01, threshold=0.8):
+    def multi_scale_search(self, org_src, org_templ, templ_min=10, src_max=800, ratio_min=0.01, 
+                            ratio_max=0.99, step=0.01, threshold=0.8, time_out=3.0):
         """多尺度模板匹配"""
         mmax_val = 0
         max_info = None
         r = ratio_min
+        t = time.time()
         while r <= ratio_max:
             src, templ, tr, sr = self._resize_by_ratio(
                 org_src.copy(), org_templ.copy(), r, src_max=src_max)
@@ -135,7 +137,8 @@ class MultiScaleTemplateMatching(object):
                     mmax_val = max_val
                     max_info = (r, max_val, max_loc, w, h, tr, sr)
                 # print((r, max_val, max_loc, w, h, tr, sr))
-                if max_val >= threshold:
+                time_cost = time.time() - t
+                if time_cost>time_out and max_val >= threshold:
                     omax_loc, ow, oh = self._org_size(max_loc, w, h, tr, sr)
                     confidence = self._get_confidence_from_matrix(omax_loc, ow, oh)
                     if confidence >= threshold:
@@ -172,7 +175,8 @@ class MultiScaleTemplateMatchingPre(MultiScaleTemplateMatching):
                 self.im_source, self.im_search, self.resolution)
             s_gray, i_gray = img_mat_rgb_2_gray(self.im_search), img_mat_rgb_2_gray(self.im_source)
             confidence, max_loc, w, h, _ = self.multi_scale_search(
-                i_gray, s_gray, ratio_min=r_min, ratio_max=r_max, step=self.scale_step, threshold=self.threshold)
+                    i_gray, s_gray, ratio_min=r_min, ratio_max=r_max, step=self.scale_step, 
+                    threshold=self.threshold, time_out=1.0)
             if not self.record_pos is None:
                 max_loc = (max_loc[0] + area[0], max_loc[1] + area[1])
             

--- a/airtest/core/android/adb.py
+++ b/airtest/core/android/adb.py
@@ -821,7 +821,11 @@ class ADB(object):
             AdbShellError if no such file
         """
         out = self.shell(["ls", "-l", filepath])
-        file_size = int(out.split()[4])
+        try:
+            file_size = int(out.split()[4])
+        except ValueError:
+            # 安卓6.0.1系统得到的结果是[3]为文件大小
+            file_size = int(out.split()[3])
         return file_size
 
     def _cleanup_forwards(self):

--- a/airtest/core/android/adb.py
+++ b/airtest/core/android/adb.py
@@ -959,11 +959,15 @@ class ADB(object):
         """
         # use adb shell wm size
         displayInfo = {}
-        wm_size = re.search(r'(?P<width>\d+)x(?P<height>\d+)\s*$', self.raw_shell('wm size'))
-        if wm_size:
-            displayInfo = dict((k, int(v)) for k, v in wm_size.groupdict().items())
-            displayInfo['density'] = self._getDisplayDensity(strip=True)
-            return displayInfo
+        try:
+            wm_size = re.search(r'(?P<width>\d+)x(?P<height>\d+)\s*$', self.raw_shell('wm size'))
+        except AdbError as e:
+            print(e)
+        else:
+            if wm_size:
+                displayInfo = dict((k, int(v)) for k, v in wm_size.groupdict().items())
+                displayInfo['density'] = self._getDisplayDensity(strip=True)
+                return displayInfo
 
         phyDispRE = re.compile('.*PhysicalDisplayInfo{(?P<width>\d+) x (?P<height>\d+), .*, density (?P<density>[\d.]+).*')
         out = self.raw_shell('dumpsys display')

--- a/airtest/core/android/recorder.py
+++ b/airtest/core/android/recorder.py
@@ -101,8 +101,8 @@ class Recorder(Yosemite):
             m = re.match("stop result: Stop ok! File path:(.*\.mp4)", line.strip())
             if m:
                 self.recording_file = m.group(1)
-                self.adb.pull(self.recording_file, output)
                 kill_proc(p)
+                self.adb.pull(self.recording_file, output)
                 return True
         kill_proc(p)
         raise AirtestError("start_recording first")

--- a/airtest/core/api.py
+++ b/airtest/core/api.py
@@ -56,6 +56,7 @@ def connect_device(uri):
         >>> connect_device("Windows:///")  # connect to the desktop
         >>> connect_device("Windows:///123456")  # Connect to the window with handle 123456
         >>> connect_device("iOS:///127.0.0.1:8100")  # iOS device
+        >>> connect_device("iOS:///http://localhost:8100/?mjpeg_port=9100")  # iOS with mjpeg port
 
     """
     d = urlparse(uri)

--- a/airtest/core/ios/constant.py
+++ b/airtest/core/ios/constant.py
@@ -24,7 +24,11 @@ LANDSCAPE_PAD_RESOLUTION = [(1242, 2208)]
 class CAP_METHOD(object):
     MINICAP = "MINICAP"
     WDACAP = "WDACAP"
+    MJPEG = "MJPEG"
 
+
+# wda default mjpeg server port number
+DEFAULT_MJPEG_PORT = 9100
 
 # now touch and ime only support wda
 class TOUCH_METHOD(object):

--- a/airtest/core/ios/ios.py
+++ b/airtest/core/ios/ios.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 # -*- coding: utf-8 -*-
 
+import re
 import time
 import base64
 import traceback
@@ -10,11 +11,11 @@ from functools import wraps
 from airtest import aircv
 from airtest.core.device import Device
 from airtest.core.ios.constant import CAP_METHOD, TOUCH_METHOD, IME_METHOD, ROTATION_MODE, KEY_EVENTS, \
-    LANDSCAPE_PAD_RESOLUTION
+    LANDSCAPE_PAD_RESOLUTION, IP_PATTERN
 from airtest.core.ios.rotation import XYTransformer, RotationWatcher
 from airtest.core.ios.instruct_cmd import InstructHelper
 from airtest.utils.logger import get_logger
-
+from airtest.core.ios.mjpeg_cap import MJpegcap
 
 LOGGING = get_logger(__name__)
 
@@ -28,6 +29,7 @@ def decorator_retry_session(func):
 
     当因为session失效而操作失败时，尝试重新获取session，最多重试3次
     """
+
     @wraps(func)
     def wrapper(self, *args, **kwargs):
         try:
@@ -41,6 +43,7 @@ def decorator_retry_session(func):
                     time.sleep(0.5)
                     continue
             raise
+
     return wrapper
 
 
@@ -71,7 +74,7 @@ class IOS(Device):
         - ``iproxy $port 8100 $udid``
     """
 
-    def __init__(self, addr=DEFAULT_ADDR):
+    def __init__(self, addr=DEFAULT_ADDR, cap_method=CAP_METHOD.WDACAP, mjpeg_port=None):
         super(IOS, self).__init__()
 
         # if none or empty, use default addr
@@ -83,7 +86,7 @@ class IOS(Device):
             self.addr = "http://" + addr
 
         """here now use these supported cap touch and ime method"""
-        self.cap_method = CAP_METHOD.WDACAP
+        self.cap_method = cap_method
         self.touch_method = TOUCH_METHOD.WDATOUCH
         self.ime_method = IME_METHOD.WDAIME
 
@@ -103,11 +106,22 @@ class IOS(Device):
 
         info = self.device_info
         self.instruct_helper = InstructHelper(info['uuid'])
+        self.mjpegcap = MJpegcap(self.instruct_helper, ori_function=lambda: self.display_info,
+                                 ip=self.ip, port=mjpeg_port)
         # start up RotationWatcher with default session
         self.rotation_watcher = RotationWatcher(self)
         self._register_rotation_watcher()
 
         self.alert_watch_and_click = self.driver.alert.watch_and_click
+
+    @property
+    def ip(self):
+        match = re.search(IP_PATTERN, self.addr)
+        if match:
+            ip = match.group(0)
+        else:
+            ip = 'localhost'
+        return ip
 
     @property
     def uuid(self):
@@ -135,7 +149,7 @@ class IOS(Device):
         if self._is_pad is None:
             info = self.device_info
             if info["model"] == "iPad" or \
-                (self.display_info["width"], self.display_info["height"]) in LANDSCAPE_PAD_RESOLUTION:
+                    (self.display_info["width"], self.display_info["height"]) in LANDSCAPE_PAD_RESOLUTION:
                 # ipad与6P/7P/8P等设备，桌面横屏时的表现一样，都会变横屏
                 self._is_pad = True
             else:
@@ -284,8 +298,9 @@ class IOS(Device):
         """
         data = None
 
-        # 暂时只有一种截图方法, WDACAP
-        if self.cap_method == CAP_METHOD.WDACAP:
+        if self.cap_method == CAP_METHOD.MJPEG:
+            data = self.mjpegcap.get_frame_from_stream()
+        elif self.cap_method == CAP_METHOD.WDACAP:
             data = self._neo_wda_screenshot()  # wda 截图不用考虑朝向
 
         # 实时刷新手机画面，直接返回base64格式，旋转问题交给IDE处理
@@ -368,7 +383,7 @@ class IOS(Device):
             raise ValueError("Invalid name: %s, should be one of ('home', 'volumeUp', 'volumeDown')" % keyname)
         else:
             self.press(keyname)
-    
+
     def press(self, keys):
         """some keys in ["home", "volumeUp", "volumeDown"] can be pressed"""
         self.driver.press(keys)
@@ -425,7 +440,7 @@ class IOS(Device):
 
         """
         self.driver.app_stop(bundle_id=package)
-    
+
     def app_state(self, package):
         """
 
@@ -452,7 +467,7 @@ class IOS(Device):
         # output {"value": 4, "sessionId": "xxxxxx"}
         # different value means 1: die, 2: background, 4: running
         return self.driver.app_state(bundle_id=package)
-    
+
     def app_current(self):
         """
         get the app current 
@@ -620,7 +635,7 @@ class IOS(Device):
 
         """
         return self.driver.alert.buttons()
-    
+
     def alert_exists(self):
         """
         get True for alert exists or False.

--- a/airtest/core/ios/ios.py
+++ b/airtest/core/ios/ios.py
@@ -349,22 +349,14 @@ class IOS(Device):
         Returns:
 
         """
-        cap_method = cap_method or self.cap_method
-        screen = None
-        if cap_method == CAP_METHOD.MJPEG:
-            try:
-                screen = self.mjpegcap.snapshot()
-            except ConnectionRefusedError:
-                pass
-        if screen is None:
-            data = self._neo_wda_screenshot()
-            # output cv2 object
-            try:
-                screen = aircv.utils.string_2_img(data)
-            except:
-                # may be black/locked screen or other reason, print exc for debugging
-                traceback.print_exc()
-                return None
+        data = self._neo_wda_screenshot()
+        # output cv2 object
+        try:
+            screen = aircv.utils.string_2_img(data)
+        except:
+            # may be black/locked screen or other reason, print exc for debugging
+            traceback.print_exc()
+            return None
 
         # save as file if needed
         if filename:

--- a/airtest/core/ios/ios.py
+++ b/airtest/core/ios/ios.py
@@ -281,7 +281,7 @@ class IOS(Device):
         # function window_size() return UIKit size, While screenshot() image size is Native Resolution
         window_size = self.window_size()
         # when use screenshot, the image size is pixels size. eg(1080 x 1920)
-        snapshot = self.snapshot(cap_method=CAP_METHOD.WDACAP)
+        snapshot = self.snapshot()
         if self.orientation in [wda.LANDSCAPE, wda.LANDSCAPE_RIGHT]:
             self._size['window_width'], self._size['window_height'] = window_size.height, window_size.width
             width, height = snapshot.shape[:2]
@@ -336,7 +336,7 @@ class IOS(Device):
         raw_value = base64.b64decode(value)
         return raw_value
 
-    def snapshot(self, filename=None, quality=10, max_size=None, cap_method=None):
+    def snapshot(self, filename=None, quality=10, max_size=None):
         """
         take snapshot
 
@@ -344,7 +344,6 @@ class IOS(Device):
             filename: save screenshot to filename
             quality: The image quality, integer in range [1, 99]
             max_size: the maximum size of the picture, e.g 1200
-            cap_method: The default is self.cap_method, but it needs to be specified as WDACAP when getting display_info
 
         Returns:
 

--- a/airtest/core/ios/ios.py
+++ b/airtest/core/ios/ios.py
@@ -300,7 +300,10 @@ class IOS(Device):
         cap_method = cap_method or self.cap_method
         screen = None
         if cap_method == CAP_METHOD.MJPEG:
-            screen = self.mjpegcap.snapshot()
+            try:
+                screen = self.mjpegcap.snapshot()
+            except ConnectionRefusedError:
+                pass
         if screen is None:
             data = self._neo_wda_screenshot()
             # output cv2 object

--- a/airtest/core/ios/ios.py
+++ b/airtest/core/ios/ios.py
@@ -306,6 +306,32 @@ class IOS(Device):
             self._display_info()
         return self._touch_factor
 
+    @touch_factor.setter
+    def touch_factor(self, factor):
+        """
+        touch_factor is used to convert click coordinates: mobile phone real coordinates = touch_factor * screen coordinates
+        In general, no manual settings are required
+
+        touch_factor用于换算点击坐标：手机真实坐标 = touch_factor * 屏幕坐标
+        默认计算方式是： self.display_info['window_height'] / self.display_info['height']
+        但在部分特殊型号手机上可能不准确，例如iOS14.4的7P，默认值为 1/3，但部分7P点击位置不准确，可自行设置为：self.touch_factor = 1 / 3.03
+        （一般情况下，无需手动设置！）
+
+        Examples:
+            >>> device = connect_device("iOS:///")
+            >>> device.touch((100, 100))  # wrong position
+            >>> print(device.touch_factor)
+            0.333333
+            >>> device.touch_factor = 1 / 3.3
+            >>> device.touch((100, 100))
+        Args:
+            factor: real_pos / pixel_pos, e.g: 1/self.driver.scale
+
+        Returns:
+
+        """
+        self._touch_factor = float(factor)
+
     def get_render_resolution(self):
         """
         Return render resolution after rotation

--- a/airtest/core/ios/ios.py
+++ b/airtest/core/ios/ios.py
@@ -74,7 +74,7 @@ class IOS(Device):
         - ``iproxy $port 8100 $udid``
     """
 
-    def __init__(self, addr=DEFAULT_ADDR, cap_method=CAP_METHOD.WDACAP, mjpeg_port=None):
+    def __init__(self, addr=DEFAULT_ADDR, cap_method=CAP_METHOD.MJPEG, mjpeg_port=None):
         super(IOS, self).__init__()
 
         # if none or empty, use default addr
@@ -82,6 +82,7 @@ class IOS(Device):
 
         # fit wda format, make url start with http://
         # eg. http://localhost:8100/ or http+usbmux://00008020-001270842E88002E
+        # with mjpeg_port: http://localhost:8100/?mjpeg_port=9100
         if not self.addr.startswith("http"):
             self.addr = "http://" + addr
 
@@ -299,7 +300,12 @@ class IOS(Device):
         data = None
 
         if self.cap_method == CAP_METHOD.MJPEG:
-            data = self.mjpegcap.get_frame_from_stream()
+            try:
+                data = self.mjpegcap.get_frame_from_stream()
+            except ConnectionRefusedError:
+                # 如果未提供端口号、默认端口也无法连接，改回使用WDACAP模式
+                self.cap_method = CAP_METHOD.WDACAP
+                data = self._neo_wda_screenshot()
         elif self.cap_method == CAP_METHOD.WDACAP:
             data = self._neo_wda_screenshot()  # wda 截图不用考虑朝向
 

--- a/airtest/core/ios/mjpeg_cap.py
+++ b/airtest/core/ios/mjpeg_cap.py
@@ -1,0 +1,131 @@
+#! /usr/bin/env python
+# -*- coding: utf-8 -*-
+import socket
+import traceback
+from airtest import aircv
+from airtest.utils.snippet import reg_cleanup, on_method_ready, ready_method
+from airtest.core.ios.constant import ROTATION_MODE, DEFAULT_MJPEG_PORT
+from airtest.utils.logger import get_logger
+
+
+LOGGING = get_logger(__name__)
+
+
+class SocketBuffer:
+    def __init__(self, sock: socket.socket):
+        self._sock = sock
+        self._buf = bytearray()
+
+    def _drain(self):
+        _data = self._sock.recv(1024)
+        if _data is None:
+            raise IOError("socket closed")
+        self._buf.extend(_data)
+        return len(_data)
+
+    def read_until(self, delimeter: bytes) -> bytes:
+        """ return without delimeter """
+        while True:
+            index = self._buf.find(delimeter)
+            if index != -1:
+                _return = self._buf[:index]
+                self._buf = self._buf[index + len(delimeter):]
+                return _return
+            self._drain()
+
+    def read_bytes(self, length: int) -> bytes:
+        while length > len(self._buf):
+            self._drain()
+
+        _return, self._buf = self._buf[:length], self._buf[length:]
+        return _return
+
+    def write(self, data: bytes):
+        return self._sock.sendall(data)
+
+
+class MJpegcap(object):
+
+    def __init__(self, instruct_helper=None, ip='localhost', port=None, ori_function=None):
+        self.instruct_helper = instruct_helper
+        self.port = port or DEFAULT_MJPEG_PORT
+        self.ip = ip
+        # 如果指定了port，说明已经将wda的9100端口映射到了新端口，无需本地重复映射
+        self.port_forwarding = True if self.port == DEFAULT_MJPEG_PORT and ip in ('localhost', '127.0.0.1') else False
+        self.ori_function = ori_function
+
+    @ready_method
+    def setup_stream_server(self):
+        if self.port_forwarding:
+            self.port, _ = self.instruct_helper.setup_proxy(9100)
+        self.init_sock()
+        reg_cleanup(self.teardown_stream)
+
+    def init_sock(self):
+        self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self.sock.connect((self.ip, self.port))
+        self.buf = SocketBuffer(self.sock)
+        self.buf.write(b"GET / HTTP/1.0\r\nHost: localhost\r\n\r\n")
+        self.buf.read_until(b'\r\n\r\n')
+        LOGGING.info("mjpegsock is ready")
+
+    @on_method_ready('setup_stream_server')
+    def get_frame_from_stream(self):
+        while True:
+            line = self.buf.read_until(b'\r\n')
+            if line.startswith(b"Content-Length"):
+                length = int(line.decode('utf-8').split(": ")[1])
+                break
+        while True:
+            if self.buf.read_until(b'\r\n') == b'':
+                break
+        imdata = self.buf.read_bytes(length)
+        return imdata
+
+    def get_frame(self):
+        # 获得单张屏幕截图
+        return self.get_frame_from_stream()
+
+    def snapshot(self, ensure_orientation=True, *args, **kwargs):
+        """
+        Take a screenshot and convert it into a cv2 image object
+
+        获取一张屏幕截图，并转化成cv2的图像对象
+
+        Args:
+            ensure_orientation: True or False whether to keep the orientation same as display
+
+        Returns: numpy.ndarray
+
+        """
+        screen = self.get_frame_from_stream()
+        try:
+            screen = aircv.utils.string_2_img(screen)
+        except Exception:
+            # may be black/locked screen or other reason, print exc for debugging
+            traceback.print_exc()
+            return None
+
+        if ensure_orientation:
+            if self.ori_function:
+                display_info = self.ori_function()
+                orientation = next(key for key, value in ROTATION_MODE.items() if value == display_info["orientation"])
+                screen = aircv.rotate(screen, -orientation, clockwise=False)
+
+        return screen
+
+    def teardown_stream(self):
+        if self.port_forwarding:
+            self.instruct_helper.remove_proxy(self.port)
+            self.port = None
+
+
+if __name__ == "__main__":
+    import wda
+    from airtest.core.ios.instruct_cmd import InstructHelper
+    addr = "http://localhost:8100"
+    driver = wda.Client(addr)
+    info = driver.info
+    instruct_helper = InstructHelper(info['uuid'])
+    mjpeg_server = MJpegcap(instruct_helper)
+    print(len(mjpeg_server.get_frame()))

--- a/airtest/core/ios/mjpeg_cap.py
+++ b/airtest/core/ios/mjpeg_cap.py
@@ -48,7 +48,7 @@ class MJpegcap(object):
 
     def __init__(self, instruct_helper=None, ip='localhost', port=None, ori_function=None):
         self.instruct_helper = instruct_helper
-        self.port = port or DEFAULT_MJPEG_PORT
+        self.port = int(port or DEFAULT_MJPEG_PORT)
         self.ip = ip
         # 如果指定了port，说明已经将wda的9100端口映射到了新端口，无需本地重复映射
         self.port_forwarding = True if self.port == DEFAULT_MJPEG_PORT and ip in ('localhost', '127.0.0.1') else False

--- a/airtest/core/win/win.py
+++ b/airtest/core/win/win.py
@@ -509,4 +509,5 @@ class Windows(Device):
         Returns:
              :py:obj:`str`: ip address
         """
-        return socket.gethostbyname(socket.gethostname())
+        hostname = socket.getfqdn()
+        return socket.gethostbyname_ex(hostname)[2][0]

--- a/airtest/report/report.py
+++ b/airtest/report/report.py
@@ -12,7 +12,11 @@ import jinja2
 import traceback
 from copy import deepcopy
 from datetime import datetime
-from jinja2 import evalcontextfilter, Markup, escape
+from jinja2 import Markup, escape
+try:
+    from jinja2 import evalcontextfilter as pass_eval_context  # jinja2<3.1
+except:
+    from jinja2 import pass_eval_context  # jinja2>=3.1
 from airtest.aircv import imread, get_resolution
 from airtest.core.settings import Settings as ST
 from airtest.aircv.utils import compress_image
@@ -32,7 +36,7 @@ STATIC_DIR = os.path.dirname(__file__)
 _paragraph_re = re.compile(r'(?:\r\n|\r|\n){2,}')
 
 
-@evalcontextfilter
+@pass_eval_context
 def nl2br(eval_ctx, value):
     result = u'\n\n'.join(u'<p>%s</p>' % p.replace('\n', '<br>\n')
                           for p in _paragraph_re.split(escape(value)))

--- a/airtest/utils/version.py
+++ b/airtest/utils/version.py
@@ -1,4 +1,4 @@
-__version__ = "1.2.4"
+__version__ = "1.2.5"
 
 import os
 import sys

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ Pillow>=3.4.0
 requests>=2.11.1
 six
 mss==6.1.0
-numpy<=1.19.3
+numpy
 opencv-contrib-python
 facebook-wda>=1.3.3
 pywinauto==0.6.3

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,8 @@ def parse_requirements(filename):
     if sys.version_info.major == 2:
         # facebook-wda only supports py3
         reqs.remove("facebook-wda>=1.3.3")
+        reqs.remove("mss==6.1.0")
+        reqs.append("mss==4.0.3")
     return reqs
 
 

--- a/tests/test_adb.py
+++ b/tests/test_adb.py
@@ -6,6 +6,8 @@ import os
 import unittest
 import subprocess
 from six import text_type
+import warnings
+warnings.simplefilter("always")
 
 
 class TestADBWithoutDevice(unittest.TestCase):

--- a/tests/test_adb.py
+++ b/tests/test_adb.py
@@ -113,6 +113,9 @@ class TestADBWithDevice(unittest.TestCase):
     def test_exists_file(self):
         self.assertTrue(self.adb.exists_file("/"))
 
+    def test_file_size(self):
+        self.assertIsInstance(self.adb.file_size("/data/local/tmp/minicap"), int)
+
     def test_push(self):
         tmpdir = "/data/local/tmp"
         imgname = os.path.basename(IMG)

--- a/tests/test_android.py
+++ b/tests/test_android.py
@@ -7,6 +7,8 @@ from threading import Thread
 from airtest.core.android.android import Android, ADB, Minicap, Minitouch, IME_METHOD, CAP_METHOD, TOUCH_METHOD
 from airtest.core.error import AirtestError
 from .testconf import APK, PKG, try_remove
+import warnings
+warnings.simplefilter("always")
 
 
 class TestAndroid(unittest.TestCase):
@@ -153,50 +155,6 @@ class TestAndroid(unittest.TestCase):
         self.android.touch_method = TOUCH_METHOD.MINITOUCH
         with self.assertRaises(Exception):
             self.android.swipe((100, 100), (300, 300), fingers=3)
-
-    def test_recording(self):
-        if self.android.sdk_version >= 19:
-            filepath = "screen.mp4"
-            if os.path.exists(filepath):
-                os.remove(filepath)
-            self.android.start_recording(max_time=30, bit_rate=500000)
-            time.sleep(10)
-            self.android.stop_recording()
-            self.assertTrue(os.path.exists("screen.mp4"))
-            time.sleep(2)
-            # Record the screen with the lower quality
-            os.remove(filepath)
-            self.android.start_recording(bit_rate_level=1)
-            time.sleep(10)
-            self.android.stop_recording()
-            self.assertTrue(os.path.exists("screen.mp4"))
-            os.remove(filepath)
-            time.sleep(2)
-            self.android.start_recording(bit_rate_level=0.5)
-            time.sleep(10)
-            self.android.stop_recording()
-            self.assertTrue(os.path.exists("screen.mp4"))
-
-    def test_start_recording_error(self):
-        if self.android.sdk_version >= 19:
-            with self.assertRaises(AirtestError):
-                self.android.start_recording(max_time=30)
-                time.sleep(3)
-                self.android.start_recording(max_time=30)
-            self.android.stop_recording()
-
-    def test_stop_recording_error(self):
-        with self.assertRaises(AirtestError):
-            self.android.stop_recording()
-
-    def test_interrupt_recording(self):
-        filepath = "screen.mp4"
-        if os.path.exists(filepath):
-            os.remove(filepath)
-        self.android.start_recording(max_time=30)
-        time.sleep(3)
-        self.android.stop_recording(is_interrupted=True)
-        self.assertFalse(os.path.exists(filepath))
 
     def test_get_top_activity(self):
         self._install_test_app()

--- a/tests/test_android_recorder.py
+++ b/tests/test_android_recorder.py
@@ -1,0 +1,80 @@
+# encoding=utf-8
+import os
+import time
+import unittest
+from airtest.core.android.android import Android
+from airtest.core.android.recorder import Recorder
+from airtest.core.error import AirtestError
+from .testconf import try_remove
+import warnings
+warnings.simplefilter("always")
+
+
+class TestAndroidRecorder(unittest.TestCase):
+    """Test Android screen recording function"""
+    @classmethod
+    def setUpClass(cls):
+        cls.android = Android()
+        cls.filepath = "screen.mp4"
+
+    @classmethod
+    def tearDownClass(cls):
+        try_remove('screen.mp4')
+
+    def tearDown(self):
+        try_remove("screen.mp4")
+
+    def test_recording(self):
+        if self.android.sdk_version >= 19:
+            self.android.start_recording(max_time=30, bit_rate=500000)
+            time.sleep(10)
+            self.android.stop_recording()
+            self.assertTrue(os.path.exists(self.filepath))
+            time.sleep(2)
+            # Record the screen with the lower quality
+            os.remove(self.filepath)
+            self.android.start_recording(bit_rate_level=1)
+            time.sleep(10)
+            self.android.stop_recording()
+            self.assertTrue(os.path.exists(self.filepath))
+            os.remove(self.filepath)
+            time.sleep(2)
+            self.android.start_recording(bit_rate_level=0.5)
+            time.sleep(10)
+            self.android.stop_recording()
+            self.assertTrue(os.path.exists(self.filepath))
+
+    def test_recording_two_recorders(self):
+        """测试用另外一个Recorder结束录制"""
+        self.android.start_recording(max_time=30)
+        time.sleep(6)
+        recorder = Recorder(self.android.adb)
+        recorder.stop_recording()
+        self.assertTrue(os.path.exists(self.filepath))
+
+    def test_start_recording_error(self):
+        """测试多次调用start_recording"""
+        if self.android.sdk_version >= 19:
+            with self.assertRaises(AirtestError):
+                self.android.start_recording(max_time=30)
+                time.sleep(6)
+                self.android.start_recording(max_time=30)
+
+    def test_stop_recording_error(self):
+        with self.assertRaises(AirtestError):
+            self.android.stop_recording()
+
+    def test_interrupt_recording(self):
+        """测试中断录屏但不导出文件"""
+        self.android.start_recording(max_time=30)
+        time.sleep(3)
+        self.android.stop_recording(is_interrupted=True)
+        self.assertFalse(os.path.exists(self.filepath))
+
+    def test_pull_last_recording_file(self):
+        self.android.start_recording(max_time=30)
+        time.sleep(3)
+        self.android.stop_recording(is_interrupted=True)
+        self.android.recorder.pull_last_recording_file()
+        self.assertTrue(os.path.exists(self.filepath))
+

--- a/tests/test_ios.py
+++ b/tests/test_ios.py
@@ -3,7 +3,8 @@ import os
 import time
 import unittest
 import numpy
-from airtest.core.ios.ios import IOS, wda
+from airtest.core.ios.ios import IOS, wda, CAP_METHOD
+from airtest import aircv
 from .testconf import try_remove
 
 text_flag = True # 控制是否运行text接口用例
@@ -16,7 +17,7 @@ class TestIos(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.ios = IOS(addr=DEFAULT_ADDR)
+        cls.ios = IOS(addr=DEFAULT_ADDR, cap_method=CAP_METHOD.WDACAP)
 
     @classmethod
     def tearDownClass(cls):
@@ -47,7 +48,11 @@ class TestIos(unittest.TestCase):
         screen = self.ios.snapshot(filename=filename)
         self.assertIsInstance(screen, numpy.ndarray)
         self.assertTrue(os.path.exists(filename))
-        # os.remove(filename)
+
+    def test_get_frames(self):
+        frame = self.ios.get_frame_from_stream()
+        frame = aircv.utils.string_2_img(frame)
+        self.assertIsInstance(frame, numpy.ndarray)
 
     def test_keyevent_home(self):
         print("test_keyevent_home")

--- a/tests/test_ios.py
+++ b/tests/test_ios.py
@@ -30,6 +30,7 @@ class TestIos(unittest.TestCase):
     def test_wda(self):
         print("test_wda")
         self.assertIsInstance(self.ios.driver, wda.Client)
+        print(self.ios.driver.session())
 
     def test_display_info(self):
         print("test_display_info")
@@ -38,6 +39,21 @@ class TestIos(unittest.TestCase):
         self.assertIsInstance(device_infos["height"], int)
         self.assertIsInstance(device_infos["orientation"], str)
         print(device_infos)
+
+    def test_window_size(self):
+        print("test window size")
+        window_size = self.ios.window_size()
+        print(window_size)
+        self.assertIsInstance(window_size.height, int)
+        self.assertIsInstance(window_size.width, int)
+        # 以下用例可能会因为wda更新而失败，到时候需要去掉 ios._display_info里的ipad横屏下的额外处理
+        if self.ios.is_pad and self.ios.home_interface():
+            self.assertEqual(window_size.width, window_size.height)
+
+    def test_using_ios_tagent(self):
+        status = self.ios.driver.status()
+        print(self.ios.using_ios_tagent)
+        self.assertEqual('Version' in status, self.ios.using_ios_tagent)
 
     def test_snapshot(self):
         print("test_snapshot")
@@ -105,6 +121,8 @@ class TestIos(unittest.TestCase):
         time.sleep(2)
         # 左往右滑
         self.ios.swipe((0.2, 0.5), (0.8, 0.5))
+        # 上往下滑，按住0.5秒后往下滑动
+        self.ios.swipe((0.5, 0.1), (0.5, 0.5), duration=0.5)
 
     def test_lock(self):
         print("test_lock")
@@ -164,7 +182,9 @@ class TestIos(unittest.TestCase):
 
     def test_device_status(self):
         print("test_get_device_status")
-        self.assertIsInstance(self.ios.device_status(), dict)
+        status = self.ios.device_status()
+        print(status)
+        self.assertIsInstance(status, dict)
 
     @unittest.skipIf(skip_alert_flag, "demonstrating skipping get_alert_exists")
     def test_alert_exists(self):

--- a/tests/test_ios.py
+++ b/tests/test_ios.py
@@ -47,7 +47,8 @@ class TestIos(unittest.TestCase):
         self.assertIsInstance(window_size.height, int)
         self.assertIsInstance(window_size.width, int)
         # 以下用例可能会因为wda更新而失败，到时候需要去掉 ios._display_info里的ipad横屏下的额外处理
-        if self.ios.is_pad and self.ios.home_interface():
+        # 当ipad 在横屏+桌面的情况下，获取到的window_size的值为 height*height，没有width的值
+        if self.ios.is_pad and self.client.orientation != 'PORTRAIT' and self.ios.home_interface():
             self.assertEqual(window_size.width, window_size.height)
 
     def test_using_ios_tagent(self):

--- a/tests/test_ios.py
+++ b/tests/test_ios.py
@@ -229,13 +229,28 @@ class TestIos(unittest.TestCase):
 
     def test_device_info(self):
         print("test_device_info")
-        print(self.ios.device_info())
+        print(self.ios.device_info)
 
     def test_home_interface(self):
         print("test_home_interface")
         self.ios.home()
         time.sleep(2)
         self.assertTrue(self.ios.home_interface())
+
+    def test_touch_factor(self):
+        """
+        在部分特殊型号的设备上，可能默认的touch_factor不能正确点击对应的位置，因此需要修正
+        Returns:
+
+        """
+        print("test touch factor")
+        print("ios.driver.scale:", self.ios.driver.scale)
+        print("display_info:", self.ios.display_info)
+        print("default touch_factor:", self.ios.touch_factor)
+        self.ios.touch((500, 500))
+        self.ios.touch_factor = 1/3.3
+        self.ios.touch((500, 500))
+
 
 
 

--- a/tests/test_ios_instruct_cmd.py
+++ b/tests/test_ios_instruct_cmd.py
@@ -5,6 +5,8 @@ import unittest
 from airtest.core.ios.ios import IOS
 from .testconf import is_port_open
 DEFAULT_ADDR = "http://localhost:8100/"  # iOS设备连接参数
+import warnings
+warnings.simplefilter("always")
 
 
 class TestInstructCmd(unittest.TestCase):
@@ -46,6 +48,11 @@ class TestInstructCmd(unittest.TestCase):
         self.ihelper.do_proxy(9101, 9100)
         time.sleep(5)
         self.assertTrue(is_port_open('localhost', 9101))
+
+    def test_do_proxy2(self):
+        self.ihelper.do_proxy(9101, 9100)
+        time.sleep(3)
+        self.ihelper.remove_proxy(9101)
 
     def test_tear_down(self):
         port, _ = self.ihelper.setup_proxy(9100)

--- a/tests/test_ios_instruct_cmd.py
+++ b/tests/test_ios_instruct_cmd.py
@@ -1,0 +1,58 @@
+# encoding=utf-8
+import os
+import time
+import unittest
+import socket
+from airtest.core.ios.ios import IOS, CAP_METHOD
+from airtest.core.ios.instruct_cmd import InstructHelper
+from airtest import aircv
+from .testconf import is_port_open
+DEFAULT_ADDR = "http://localhost:8100/"  # iOS设备连接参数
+
+
+class TestInstructCmd(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.ios = IOS(DEFAULT_ADDR)
+        cls.ihelper = cls.ios.instruct_helper
+
+    @classmethod
+    def tearDownClass(cls):
+        pass
+
+    def tearDown(self):
+        self.ihelper.tear_down()
+
+    def test_setup_proxy(self):
+        port, _ = self.ihelper.setup_proxy(9100)
+        self.assertTrue(is_port_open('localhost', port))
+
+    def test_remove_proxy(self):
+        port, _ = self.ihelper.setup_proxy(9100)
+        self.assertTrue(is_port_open('localhost', port))
+        time.sleep(2)
+        self.ihelper.remove_proxy(port)
+        time.sleep(2)
+        self.assertFalse(is_port_open('localhost', port))
+
+    def test_do_proxy_usbmux(self):
+        # 仅当连接本地usb设备时才可用
+        self.assertFalse(is_port_open('localhost', 9100))
+        time.sleep(1)
+        self.ihelper.do_proxy_usbmux(9100, 9100)
+        time.sleep(5)
+        self.assertTrue(is_port_open('localhost', 9100))
+
+    def test_do_proxy(self):
+        self.assertFalse(is_port_open('localhost', 9101))
+        time.sleep(1)
+        self.ihelper.do_proxy(9101, 9100)
+        time.sleep(5)
+        self.assertTrue(is_port_open('localhost', 9101))
+
+    def test_tear_down(self):
+        port, _ = self.ihelper.setup_proxy(9100)
+        self.assertTrue(is_port_open('localhost', port))
+        self.ihelper.tear_down()
+        time.sleep(3)
+        self.assertFalse(is_port_open('localhost', port))

--- a/tests/test_ios_instruct_cmd.py
+++ b/tests/test_ios_instruct_cmd.py
@@ -2,10 +2,7 @@
 import os
 import time
 import unittest
-import socket
-from airtest.core.ios.ios import IOS, CAP_METHOD
-from airtest.core.ios.instruct_cmd import InstructHelper
-from airtest import aircv
+from airtest.core.ios.ios import IOS
 from .testconf import is_port_open
 DEFAULT_ADDR = "http://localhost:8100/"  # iOS设备连接参数
 

--- a/tests/test_ios_mjpeg.py
+++ b/tests/test_ios_mjpeg.py
@@ -62,6 +62,10 @@ class TestIosMjpeg(unittest.TestCase):
             time.sleep(0.05)
         cv2.destroyAllWindows()
 
+    def test_get_blank_screen(self):
+        img_string = self.mjpeg_server.get_blank_screen()
+        img = aircv.utils.string_2_img(img_string)
+        aircv.show(img)
 
     def test_teardown_stream(self):
         self.mjpeg_server.get_frame()

--- a/tests/test_ios_mjpeg.py
+++ b/tests/test_ios_mjpeg.py
@@ -1,0 +1,41 @@
+# encoding=utf-8
+import os
+import time
+import unittest
+from airtest.core.ios.ios import IOS, CAP_METHOD
+from airtest import aircv
+from .testconf import try_remove, is_port_open
+
+DEFAULT_ADDR = "http://localhost:8100/"  # iOS设备连接参数
+DEFAULT_PORT = 9100
+
+
+class TestIosMjpeg(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.ios = IOS(DEFAULT_ADDR, cap_method=CAP_METHOD.MJPEG, mjpeg_port=DEFAULT_PORT)
+        cls.mjpeg_server = cls.ios.mjpegcap
+
+    @classmethod
+    def tearDownClass(cls):
+        try_remove('screen.png')
+
+    def test_get_frame(self):
+        for i in range(5):
+            data = self.mjpeg_server.get_frame()
+            filename = "./screen.jpg"
+            with open(filename, "wb") as f:
+                f.write(data)
+            self.assertTrue(os.path.exists(filename))
+            time.sleep(2)
+
+    def test_snapshot(self):
+        screen = self.mjpeg_server.snapshot(ensure_orientation=True)
+        aircv.show(screen)
+
+    def test_teardown_stream(self):
+        self.mjpeg_server.get_frame()
+        if self.mjpeg_server.port_forwarding is True:
+            self.assertTrue(is_port_open(self.mjpeg_server.ip, self.mjpeg_server.port))
+            self.mjpeg_server.teardown_stream()
+            self.assertFalse(is_port_open(self.mjpeg_server.ip, self.mjpeg_server.port))

--- a/tests/test_ios_mjpeg.py
+++ b/tests/test_ios_mjpeg.py
@@ -30,6 +30,7 @@ class TestIosMjpeg(unittest.TestCase):
             time.sleep(2)
 
     def test_snapshot(self):
+        # 测试截图，可以手动将设备横屏后再运行确认截图的方向是否正确
         screen = self.mjpeg_server.snapshot(ensure_orientation=True)
         aircv.show(screen)
 

--- a/tests/test_motionevents.py
+++ b/tests/test_motionevents.py
@@ -1,0 +1,66 @@
+# encoding=utf-8
+from airtest.core.android.android import ADB, Android
+from airtest.core.android.touch_methods.base_touch import MotionEvent, DownEvent, UpEvent, MoveEvent, SleepEvent
+import unittest
+import warnings
+import time
+warnings.simplefilter("always")
+
+
+class TestMotionEvents(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.device = Android()
+
+    @classmethod
+    def tearDownClass(cls):
+        pass
+
+    def test_multi_touch(self):
+        """
+        测试两指同时点击
+        """
+        multitouch_event = [
+            DownEvent((100, 100), 0),
+            DownEvent((300, 300), 1),  # second finger
+            SleepEvent(1),
+            UpEvent(0), UpEvent(1)]
+
+        self.device.touch_proxy.perform(multitouch_event)
+
+    def test_swipe(self):
+        """
+        测试滑动
+        """
+        swipe_event = [DownEvent((500, 500)), SleepEvent(0.1)]
+
+        for i in range(5):
+            swipe_event.append(MoveEvent((500 + 100 * i, 500 + 100 * i)))
+            swipe_event.append(SleepEvent(0.2))
+
+        swipe_event.append(UpEvent())
+
+        self.device.touch_proxy.perform(swipe_event)
+
+    def test_retry_touch(self):
+        """
+        测试在指令内容异常时，能够自动尝试重连
+
+        """
+        # 在安卓10部分型号手机上，如果乱序发送指令，可能会导致maxtouch断开连接
+        events = [MoveEvent((100, 100), 0),  UpEvent(), DownEvent((165, 250), 0), SleepEvent(0.2), UpEvent(), DownEvent((165, 250), 0), SleepEvent(0.2), UpEvent()]
+        self.device.touch_proxy.perform(events)
+        time.sleep(3)
+        self.device.touch((165, 250))
+
+    def test_horizontal(self):
+        """
+        如果设备是横屏，必须要加上坐标转换（竖屏也可以加）
+        """
+        ori_transformer = self.device.touch_proxy.ori_transformer
+        touch_landscape_point = [DownEvent(ori_transformer((100, 100))), SleepEvent(1), UpEvent()]
+        self.device.touch_proxy.perform(touch_landscape_point)
+
+
+

--- a/tests/testconf.py
+++ b/tests/testconf.py
@@ -2,6 +2,7 @@ from airtest.core.cv import Template
 
 import os
 import shutil
+import socket
 
 
 THISDIR = os.path.dirname(__file__)
@@ -20,3 +21,16 @@ def try_remove(filepath):
             os.remove(filepath)
         else:
             shutil.rmtree(filepath)
+
+
+def is_port_open(ip, port):
+    """
+    测试端口是否可用
+    """
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        s.connect((ip, int(port)))
+        s.shutdown(socket.SHUT_RDWR)
+        return True
+    except:
+        return False

--- a/tests/testconf.py
+++ b/tests/testconf.py
@@ -34,3 +34,5 @@ def is_port_open(ip, port):
         return True
     except:
         return False
+    finally:
+        s.close()


### PR DESCRIPTION
本次更新内容很多，主要有以下几个方面：

## 新增内容

### iOS的投屏方式优化，新增MJPEG模式

wda有一个9100端口，提供了速度较快的屏幕投影方式，假如iOS手机是本机USB连接的手机，可以使用iproxy将9100端口号映射到本机端口上，然后读取该端口的内容就是截图，速度比之前使用facebook.wda的截图接口一张一张截图快很多。

涉及到改动的文件：

- `airtest/core/ios.py`：
  - 默认的屏幕截图模式改为`MJPEG`模式，即默认尝试从9100端口读取屏幕图像
  - 但是MJPEG模式在截图时，假如不是连续读取，而是sleep一会再读取第二帧的话，读到的内容将不是最新的帧，因此假如调用`snapshot`接口时需要拿到最新截图，必须得使用原先的默认截图接口（例如在airtest脚本运行时，每次调用snapshot就必须使用原截图接口）
- `airtest/core/instruct_cmd.py` 
  - 增加了端口映射的断开机制，可以单独断开某个端口，并且处理了资源回收
- 新增`airtest/core/ios/mjpeg_cap.py`文件，https://github.com/AirtestProject/Airtest/blob/v1.2.5/airtest/core/ios/mjpeg_cap.py
  - 实现了从9100端口读取屏幕画面的内容
- tests的新增，上述改动可以在所有关联的单元测试文件中找到用例示例：
  - https://github.com/AirtestProject/Airtest/blob/v1.2.5/tests/test_ios_instruct_cmd.py
  - https://github.com/AirtestProject/Airtest/blob/v1.2.5/tests/test_ios_mjpeg.py
 
关联的重要commit：
https://github.com/AirtestProject/Airtest/commit/9fadd51e0bdfd15826b386d0643db6b3819fff01
https://github.com/AirtestProject/Airtest/commit/4fb7940bb8d632ebed7edae35be9051d153584df

为了解决在插拔手机时可能导致的卡住问题，进行了一些问题修复
https://github.com/AirtestProject/Airtest/commit/54abda7d2dd708c587b9d802a8579ebf78515d5f
https://github.com/AirtestProject/Airtest/commit/f27ccb345efb06b42af8a01300cb5baa5364c5b5

### iOS的点击速度优化

需要配合即将更新的iOS-Tagent更新才可用，否则依然调用Appium/WebDriverAgant的旧接口。

主要改动为：优化了wda中的点击速度和滑动速度，但是为了更快的速度，所有的点击坐标都是竖屏坐标。
因此，假如当前连接的是新版本ios-tagent，就使用竖屏坐标。
否则，根据目前4.1.4版本的WDA测试结果，竖屏时使用竖屏坐标，横屏使用横屏坐标，ipad设备在横屏桌面下，有可能有特殊处理。

关联的commit：
https://github.com/AirtestProject/Airtest/commit/b6f14b1b3030c4e5ad7f4be018b655ea19ad87e7 新增了一个值用于判断是否是最新的ios-tagent

备忘：
在部分设备上可能点击位置会有偏移，需要特殊设置ios.touch_factor的值来修正偏移。目前已知例如某些7P需要将默认的值从1/3改为1/3.3才能正确点击。

## BUG修改

修复了一个安卓录屏模块中的资源未完全释放的问题，并把录屏模块的单元测试用例独立出来作为单独的文件（tests/test_android_recorder.py）。录屏功能使用了多个process和nbsp，并且中途可能会有终止录屏的操作，之前没有进行清理的话，会导致录屏进程一直在后台开着，长期累积下来会导致问题。
https://github.com/AirtestProject/Airtest/pull/1034/commits/7c196272b760c39602dbe9fb6622504ec8a5863d

## 其他小改动

1. 优化了mstpl的识别效果 3cfb89b4b11641290fbde7781ef85c3dc26ca7a0
2. 安卓10手机在建立点击的maxtouch连接过程中，如果此时有错误数据发送过去可能会导致服务挂掉，如果出现了这种情况就再尝试重新建立一次连接  d47dea89401acc9e18b9c603507e36d53b76c8d3
3. 去掉了安装时对numpy版本号的限制
4. 假如本地安装的jinjia2版本号大于3.1，会因为接口改动导致无法使用，已经兼容了3.1以上的接口名 5ed99a5d687b40dc65211e7b9ae16880b26955cb
5. windows下面获取本机ip可能会有问题，尝试换了一个接口来获取，但可能在某些机器上还是不行 82857600b96a1b6b49219f4711db854bf4b0a0d3