### PR TITLE
fix: report pocoui style exception

### DIFF
--- a/airtest/report/css/report.css
+++ b/airtest/report/css/report.css
@@ -457,6 +457,7 @@ h2.empty-report{
 }
 .fluid.infos{
   min-width: 300px;
+  word-break: break-all;
 }
 .step-right .fluid.screens, .step-right .fluid.traces{
   width: 100%;


### PR DESCRIPTION
- 生成报告时，没导入poco报告插件的情况下，报告中pocoui样式异常。
- 期望：没倒入的时候也正常展示，可能大多数人，不会在代码中倒入报告插件！！！

https://github.com/AirtestProject/Airtest/issues/1035

![image](https://user-images.githubusercontent.com/29191106/161371166-ee338695-e736-4ea2-819f-826b2d55ec2e.png)

report.css中 增加了  **word-break: break-all;**

`.fluid.infos{
  min-width: 300px;
  word-break: break-all;
}`


<img width="1378" alt="image" src="https://user-images.githubusercontent.com/29191106/161371048-abd5090e-7cbd-4816-9305-50c98f3fe090.png">

增加后，样式正常，没有超出屏幕