### PR TITLE
fix: android gets device ip address as none

### DIFF
--- a/airtest/core/android/adb.py
+++ b/airtest/core/android/adb.py
@@ -1417,7 +1417,7 @@ class ADB(object):
         interfaces = ('eth0', 'eth1', 'wlan0')
         for i in interfaces:
             ip = get_ip_address_from_interface(i)
-            if ip and not ip.startswith('172.') and not ip.startswith('127.') and not ip.startswith('169.'):
+            if ip and not ip.startswith('127.') and not ip.startswith('169.'):
                 return ip
 
         return None


### PR DESCRIPTION
https://github.com/AirtestProject/Airtest/issues/1038

- 172开头是B类地址，每个B类地址可连接64516台主机
- 公司大部分是172开头的ip，期望放开限制

**如下，正常获取IP**

![image](https://user-images.githubusercontent.com/29191106/162360259-261d9394-a7ed-4d37-80f4-9892f0a983f0.png)
