### PR TITLE
Import Markup() from markupsafe instead of jinja2

### DIFF
--- a/airtest/report/report.py
+++ b/airtest/report/report.py
@@ -12,7 +12,7 @@ import jinja2
 import traceback
 from copy import deepcopy
 from datetime import datetime
-from jinja2 import Markup, escape
+from markupsafe import Markup, escape
 try:
     from jinja2 import evalcontextfilter as pass_eval_context  # jinja2<3.1
 except:


### PR DESCRIPTION
- https://github.com/AirtestProject/Airtest/issues/1033

The latest jinja2 (released today) does not support jinja2.Markup, see [here](https://jinja.palletsprojects.com/en/3.1.x/changes/?highlight=markup#version-3-1-0). Instead, it states Markup should be imported from markupsafe.

I can submit a PR to either:

- Add the `markupsafe` dependency (I believe it's already required by `jinja2`) and change the code to import `Markup` accordingly

Thoughts?

![image](https://user-images.githubusercontent.com/29191106/163392748-eee983d2-705c-4592-a922-a3b54bfc34ee.png)

