### PR TITLE
修复win和linux的start_app缺少的传参

### DIFF
--- a/airtest/core/linux/linux.py
+++ b/airtest/core/linux/linux.py
@@ -142,7 +142,7 @@ class Linux(Device):
         time.sleep(interval)
         self.mouse.release(coords=(to_x, to_y))
 
-    def start_app(self, path):
+    def start_app(self, path, *args, **kwargs):
         """
         Start the application
 

--- a/airtest/core/win/win.py
+++ b/airtest/core/win/win.py
@@ -361,7 +361,7 @@ class Windows(Device):
             coords = self._action_pos(win32api.GetCursorPos())
             self.mouse.release(button=button, coords=coords)
 
-    def start_app(self, path, **kwargs):
+    def start_app(self, path, *args, **kwargs):
         """
         Start the application
 


### PR DESCRIPTION
win和linux的start_app漏了`activity`,会导致传参错误
```python
from airtest.core.api import *

init_device(platform="Windows")

start_app(r'test.exe')

Traceback (most recent call last):
  File "D:/python/Airtest/main.py", line 5, in <module>
    start_app(r'test.exe')
  File "D:\python\Airtest\airtest\utils\logwraper.py", line 90, in wrapper
    res = f(*args, **kwargs)
  File "D:\python\Airtest\airtest\core\api.py", line 184, in start_app
    G.DEVICE.start_app(package, activity)
TypeError: start_app() takes 2 positional arguments but 3 were given
```