### PR TITLE
Support for optionally setting a window foreground when connecting the window

### DIFF
--- a/airtest/core/api.py
+++ b/airtest/core/api.py
@@ -55,6 +55,7 @@ def connect_device(uri):
         >>> connect_device("Android://127.0.0.1:5037/10.254.60.1:5555")
         >>> connect_device("Windows:///")  # connect to the desktop
         >>> connect_device("Windows:///123456")  # Connect to the window with handle 123456
+        >>> connect_device("Windows:///123456?foreground=False")  # Connect to the window without setting it foreground
         >>> connect_device("iOS:///127.0.0.1:8100")  # iOS device
         >>> connect_device("iOS:///http://localhost:8100/?mjpeg_port=9100")  # iOS with mjpeg port
 

--- a/airtest/core/win/win.py
+++ b/airtest/core/win/win.py
@@ -56,7 +56,7 @@ class Windows(Device):
 
     def _init_connect(self, handle, kwargs):
         if handle:
-            self.connect(handle=handle)
+            self.connect(handle=handle, **kwargs)
         elif kwargs:
             self.connect(**kwargs)
 
@@ -81,7 +81,8 @@ class Windows(Device):
                     kwargs[k] = int(kwargs[k])
             self.app = self._app.connect(**kwargs)
             self._top_window = self.app.top_window().wrapper_object()
-        self.set_foreground()
+        if kwargs.get("foreground", True) in (True, "True", "true"):
+            self.set_foreground()
 
     def shell(self, cmd):
         """

--- a/playground/win_ide.py
+++ b/playground/win_ide.py
@@ -30,7 +30,8 @@ class WindowsInIDE(Windows):
         self.app = self._app.connect(**kwargs)
         try:
             self._top_window = self.app.top_window().wrapper_object()
-            self.set_foreground()
+            if kwargs.get("foreground", True) in (True, "True", "true"):
+                self.set_foreground()
         except RuntimeError:
             self._top_window = None
 


### PR DESCRIPTION
该 PR 目的：在 Windows 环境下，初始化`airtest.core.win.Windows`对象时，允许开发者选择性跳过`connect()`方法中的`set_foreground()`功能。

## 特殊场景

我们在 Windows 环境下调用`airtest.core.api.connect_device(uri)`方法发现某个窗口（实际样式是菜单）闪了一下就消失了。

![disappear](https://user-images.githubusercontent.com/21337386/178988507-d3ffec9a-2ad4-4f74-8840-0900995faeb5.gif)

在`airtest.core.win.Windows`源码中，发现对象在初始化时会调用一次`set_foreground()`方法。
（似乎该窗口接收到任意非鼠标点击指令都会触发关闭事件？）

得益于 Python 的特性和 Airtest 的`CUSTOM_DEVICES`的设计，我们临时通过以下方式禁用了该功能：

```python
from airtest.core.helper import G
from airtest.core.win import Windows

class HackingWindows(Windows):
    def connect(self, handle=None, **kwargs):
        if handle:
            handle = int(handle)
            self.app = self._app.connect(handle=handle)
            self._top_window = self.app.window(handle=handle).wrapper_object()
        else:
            for k in ["process", "timeout"]:
                if k in kwargs:
                    kwargs[k] = int(kwargs[k])
            self.app = self._app.connect(**kwargs)
            self._top_window = self.app.top_window().wrapper_object()
        # Eureka! We've got it.
        #self.set_foreground()

G.CUSTOM_DEVICES['windows'] = HackingWindows
```

虽然这种方式可以解决上述的问题，但是实现不够优雅，于是希望能将其作为一个 featrue 实现。

## 实现方案

为`airtest.core.win.Windows`的`connect`方法新增一个`foreground`参数，默认为`True`，与原行为保持一致。

## 使用方法

```python
d = connect_device("Windows:///123456?foreground=False")
```

```python
w = Windows(handle=123456, foreground=False)
```

------

最后，非常感谢 Airtest 的各位 Maintainers 和 Contributors，Airtest 不仅在自动化测试方面很优秀，在其他场景也非常好用，例如：我们使用 Airtest 实现了机器人流程自动化。
希望能和大家共同完善项目。
