### PR TITLE
Opt: specification for package name when get_render_resolution in an Android device

### DIFF
--- a/airtest/core/android/adb.py
+++ b/airtest/core/android/adb.py
@@ -1594,7 +1594,7 @@ class ADB(object):
                 ret[k] = v
         return ret
 
-    def get_display_of_all_screen(self, info):
+    def get_display_of_all_screen(self, info, package=None):
         """
         Perform `adb shell dumpsys window windows` commands to get window display of application.
 
@@ -1609,7 +1609,7 @@ class ADB(object):
         output = self.shell("dumpsys window windows")
         windows = output.split("Window #")
         offsetx, offsety, width, height = 0, 0, info['width'], info['height']
-        package = self._search_for_current_package(output)
+        package = self._search_for_current_package(output) if package is None else package
         if package:
             for w in windows:
                 if "package=%s" % package in w:

--- a/airtest/core/android/adb.py
+++ b/airtest/core/android/adb.py
@@ -1600,6 +1600,7 @@ class ADB(object):
 
         Args:
             info: device screen properties
+            package: package name, default to the package of top activity
 
         Returns:
             None if adb command failed to run, otherwise return device screen properties(portrait mode)

--- a/airtest/core/android/android.py
+++ b/airtest/core/android/android.py
@@ -750,19 +750,20 @@ class Android(Device):
             w, h = h, w
         return w, h
 
-    def get_render_resolution(self, refresh=False):
+    def get_render_resolution(self, refresh=False, package=None):
         """
         Return render resolution after rotation
 
         Args:
             refresh: whether to force refresh render resolution
+            package: package name, default to the package of top activity
 
         Returns:
             offset_x, offset_y, offset_width and offset_height of the display
 
         """
         if refresh or 'offset_x' not in self._display_info:
-            self.adjust_all_screen()
+            self.adjust_all_screen(package)
         x, y, w, h = self._display_info.get('offset_x', 0), \
             self._display_info.get('offset_y', 0), \
             self._display_info.get('offset_width', 0), \
@@ -857,7 +858,7 @@ class Android(Device):
         )
         return x, y
 
-    def adjust_all_screen(self):
+    def adjust_all_screen(self, package=None):
         """
         Adjust the render resolution for all_screen device.
 
@@ -866,7 +867,7 @@ class Android(Device):
 
         """
         info = self.display_info
-        ret = self.adb.get_display_of_all_screen(info)
+        ret = self.adb.get_display_of_all_screen(info, package)
         if ret:
             info.update(ret)
             self._display_info = info

--- a/airtest/core/android/android.py
+++ b/airtest/core/android/android.py
@@ -862,6 +862,9 @@ class Android(Device):
         """
         Adjust the render resolution for all_screen device.
 
+        Args:
+            package: package name, default to the package of top activity
+
         Return:
             None
 


### PR DESCRIPTION
在Android.get_render_resolution中增加应用包名参数  
这使得get_render_resolution能够获取到除top activity以外的应用的渲染区域  
理由有二:  

**首先**:有些应用会创建悬浮窗,导致top activity并不是用户所关注的应用,例如在我的手机上  
```
PS D:\> adb -s 10.0.0.9:5555 shell dumpsys activity top | findstr "ACTIVITY"
  ... only shows the last 2 lines ...
  ACTIVITY com.tencent.mobileqq/.activity.SplashActivity 4a97d1 pid=10070
  ACTIVITY com.android.systemui/.bubbles.BubbleOverflowActivity 2c11f28 pid=2608
```
我想调试QQ,但是当前的top activity是一个[气泡](https://developer.android.google.cn/guide/topics/ui/bubbles),即使我一直在QQ中收发消息,并且现在屏幕上根本见不着这个气泡,  
这使得我不得不通过某些手段杀掉这个气泡才能获取到qq的渲染区域,这是非常不方便的  

**其次**:由于先前的get_render_resolution需要获取top acvity,在我的手机上这最终会从dumpsys activity top命令中获取,而该命令执行缓慢,通常需要2-3秒才能执行完毕,这使得如果我把get_render_resolution注册到rotation_watcher--屏幕旋转后原本在左边的黑边就跑到右边去了所以要重新获取渲染区域--就会带来一些表现问题,我希望能够加速这一过程  

**最后**:render resolution本就是每个应用都有,能够指定应用包名而非限制顶层应用更加符合get_render_resolution的语义