### PR TITLE
V1.2.10

### DIFF
--- a/airtest/cli/runner.py
+++ b/airtest/cli/runner.py
@@ -38,6 +38,8 @@ class AirtestCase(unittest.TestCase):
                     dev.start_recording()
                 except:
                     traceback.print_exc()
+        # support for if __name__ == '__main__'
+        self.scope['__name__'] = '__main__'
 
     def tearDown(self):
         if self.args.log and self.args.recording:

--- a/airtest/core/ios/ios.py
+++ b/airtest/core/ios/ios.py
@@ -413,7 +413,6 @@ class IOS(Device):
 
     def touch(self, pos, duration=0.01):
         """
-
         Args:
             pos: coordinates (x, y), can be float(percent) or int
             duration (optional): tap_hold duration
@@ -426,20 +425,40 @@ class IOS(Device):
 
         """
         # trans pos of click, pos can be percentage or real coordinate
-        x, y = self._transform_xy(pos)
-        self.driver.click(x, y, duration)
+        # x, y = self._transform_xy(pos)
+        x, y = pos
+        if not (x < 1 and y < 1):
+            x, y = int(x * self.touch_factor), int(y * self.touch_factor)
+        # 根据用户安装的wda版本判断是否调用快速点击接口
+        if self.using_ios_tagent:
+            x, y = self._transform_xy(pos)
+            self._quick_click(x, y, duration)
+        else:
+            self.driver.click(x, y, duration)
+
+    def _quick_click(self, x, y, duration):
+        """
+        The method extended from the facebook-wda third-party library
+        Use modified appium wda to perform quick click
+        
+        Args:
+            x, y (int, float): float(percent), int(coordicate)
+            duration (optional): tap_hold duration
+        """
+        x, y = self.driver._percent2pos(x, y)
+        data = {'x': x, 'y': y, 'duration': duration}
+        return self.driver._session_http.post('/wda/tap', data=data)
 
     def double_click(self, pos):
         x, y = self._transform_xy(pos)
         self.driver.double_tap(x, y)
 
-    def swipe(self, fpos, tpos, duration=0, *args, **kwargs):
+    def swipe(self, fpos, tpos, duration=None, delay=0.1, *args, **kwargs):
         """
-
         Args:
             fpos: start point
             tpos: end point
-            duration (float): start coordinate press duration (seconds), default is 0
+            duration (float): start coordinate press duration (seconds), default is None
 
         Returns:
             None
@@ -449,9 +468,40 @@ class IOS(Device):
             >>> swipe((0.2, 0.5), (0.8, 0.5))
 
         """
-        fx, fy = self._transform_xy(fpos)
-        tx, ty = self._transform_xy(tpos)
-        self.driver.swipe(fx, fy, tx, ty, duration)
+        fx, fy = fpos
+        tx, ty = tpos
+        if not (fx < 1 and fy < 1):
+            fx, fy = int(fx * self.touch_factor), int(fy * self.touch_factor)
+        if not (tx < 1 and ty < 1):
+            tx, ty = int(tx * self.touch_factor), int(ty * self.touch_factor)
+        # 如果用户想长按就调用wda的dragfromtoforduration接口 否则根据wda安装版本判断是否调用快速滑动接口
+        if duration:
+            self.driver.swipe(fx, fy, tx, ty, duration)
+        else:
+            if self.using_ios_tagent:
+                # 调用自定义的wda swipe接口需要进行坐标转换
+                fx, fy = self._transform_xy(fpos)
+                tx, ty = self._transform_xy(tpos)
+                self._quick_swipe(fx, fy, tx, ty, delay)
+            else:
+                self.driver.swipe(fx, fy, tx, ty)
+
+    def _quick_swipe(self, x1, y1, x2, y2, delay):
+        """
+        The method extended from the facebook-wda third-party library
+        Use modified appium wda to perform quick swipe
+        
+        Args:
+            x1, y1, x2, y2 (int, float): float(percent), int(coordicate)
+            delay (float): start coordinate to end coordinate duration (seconds)
+        """
+        if any(isinstance(v, float) for v in [x1, y1, x2, y2]):
+            size = self.window_size()
+            x1, y1 = self.driver._percent2pos(x1, y1, size)
+            x2, y2 = self.driver._percent2pos(x2, y2, size)
+
+        data = dict(fromX=x1, fromY=y1, toX=x2, toY=y2, delay=delay)
+        return self.driver._session_http.post('/wda/swipe', data=data)
 
     def keyevent(self, keyname, **kwargs):
         """
@@ -478,6 +528,7 @@ class IOS(Device):
     def text(self, text, enter=True):
         """
         Input text on the device
+
         Args:
             text:  text to input
             enter: True if you need to enter a newline at the end
@@ -579,7 +630,10 @@ class IOS(Device):
             raise if no IP address has been found, otherwise return the IP address
 
         """
-        return self.driver.status()['ios']['ip']
+        # return self.driver.status()['ios']['ip']
+        # 修改过的wda先尝试获取wifiIP
+        ios_status = self.driver.status()['ios']
+        return ios_status.get('wifiIP', ios_status['ip'])
 
     def device_status(self):
         """

--- a/airtest/core/ios/ios.py
+++ b/airtest/core/ios/ios.py
@@ -151,6 +151,10 @@ class IOS(Device):
         return self._udid or self.addr
 
     @property
+    def udid(self):
+        return self._udid
+
+    @property
     def using_ios_tagent(self):
         """
         当前基础版本：appium/WebDriverAgent 4.1.4

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import codecs
+import platform
 import pkg_resources
 from setuptools import setup, find_packages
 
@@ -36,6 +37,10 @@ def parse_requirements(filename):
         reqs.remove("facebook-wda>=1.3.3")
         reqs.remove("mss==6.1.0")
         reqs.append("mss==4.0.3")
+    # m1 mac, python>3.6
+    if platform.processor() == "arm":
+        reqs.remove("numpy<=1.19.5")
+        reqs.append("numpy")
     return reqs
 
 

--- a/setup.py
+++ b/setup.py
@@ -73,6 +73,12 @@ setup(
     """,
     classifiers=[
         'Programming Language :: Python :: 2.7',
-        'Programming Language:: Python:: 3'
+        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
     ],
 )


### PR DESCRIPTION
最大的改动（已经merge在master上了）是新增了chatGPT自动代码审查 ^^


改动列表：

1. 本次提交主要为了兼容最新版本的ios-tagent的改动：新增了一个点击接口、一个滑动接口，速度比appium/wda的接口更快（具体详细改动内容：https://github.com/AirtestProject/iOS-Tagent/wiki/iOS-Tagent%E6%8E%A5%E5%8F%A3%E6%94%B9%E5%8A%A8%E8%AF%B4%E6%98%8E）
2. airtest将在检查到当前ios手机使用的是ios-tagent时，调用新增接口，否则调用wda原本的点击和滑动接口
3. 更新了yosemite.apk，修复了一个小米6手机横屏画面获取错误的问题
4. airtest的脚本内容支持 `if __name__ == "__main__"` 的写法了