### PR TITLE
V1.2.10.1

### DIFF
--- a/airtest/aircv/screen_recorder.py
+++ b/airtest/aircv/screen_recorder.py
@@ -61,10 +61,6 @@ class VidWriter:
                 .run_async(pipe_stdin=True)
             )
             self.writer = self.process.stdin
-        elif self.mode == "cv2":
-            fourcc = cv2.VideoWriter_fourcc('m', 'p', '4', 'v')
-            self.writer = cv2.VideoWriter(
-                outfile, fourcc, self.fps, (width, height))
 
     def process_frame(self, frame):
         assert len(frame.shape) == 3
@@ -90,8 +86,6 @@ class VidWriter:
             self.writer.close()
             self.process.wait()
             self.process.terminate()
-        elif self.mode == "cv2":
-            self.writer.release()
 
 
 class ScreenRecorder:

--- a/airtest/core/android/android.py
+++ b/airtest/core/android/android.py
@@ -877,7 +877,7 @@ class Android(Device):
             return frame
 
         self.recorder = ScreenRecorder(
-            save_path, get_frame, mode=mode, fps=fps,
+            save_path, get_frame, fps=fps,
             snapshot_sleep=snapshot_sleep, orientation=orientation)
         self.recorder.stop_time = max_time
         self.recorder.start()

--- a/airtest/core/android/android.py
+++ b/airtest/core/android/android.py
@@ -792,10 +792,9 @@ class Android(Device):
         Args:
             max_time: maximum screen recording time, default is 1800
             output: ouput file path
-            mode: the backend write video, choose in ["ffmpeg", "cv2"]
+            mode: the backend write video, choose in ["ffmpeg", "yosemite"]
                 yosemite: yosemite backend, higher quality.
                 ffmpeg: ffmpeg-python backend, higher compression rate.
-                cv2: cv2.VideoWriter backend, more stable.
             fps: frames per second will record
             snapshot_sleep: sleep time for each snapshot.
             orientation: 1: portrait, 2: landscape, 0: rotation, default is 0

--- a/airtest/core/ios/ios.py
+++ b/airtest/core/ios/ios.py
@@ -857,9 +857,8 @@ class IOS(Device):
         Args:
             max_time: maximum screen recording time, default is 1800
             output: ouput file path
-            mode: the backend write video, choose in ["ffmpeg", "cv2"]
+            mode: the backend write video, choose in ["ffmpeg"]
                 ffmpeg: ffmpeg-python backend, higher compression rate.
-                cv2: cv2.VideoWriter backend, more stable.
             fps: frames per second will record
             snapshot_sleep: sleep time for each snapshot.
             orientation: 1: portrait, 2: landscape, 0: rotation, default is 0

--- a/airtest/core/ios/ios.py
+++ b/airtest/core/ios/ios.py
@@ -849,16 +849,14 @@ class IOS(Device):
         if self.rotation_watcher:
             self.rotation_watcher.teardown()
     
-    def start_recording(self, max_time=1800, output=None, fps=10, mode="ffmpeg",
-                        snapshot_sleep=0.001, orientation=0):
+    def start_recording(self, max_time=1800, output=None, fps=10,
+                        snapshot_sleep=0.001, orientation=0, *args, **kwargs):
         """
         Start recording the device display
 
         Args:
             max_time: maximum screen recording time, default is 1800
             output: ouput file path
-            mode: the backend write video, choose in ["ffmpeg"]
-                ffmpeg: ffmpeg-python backend, higher compression rate.
             fps: frames per second will record
             snapshot_sleep: sleep time for each snapshot.
             orientation: 1: portrait, 2: landscape, 0: rotation, default is 0
@@ -914,7 +912,7 @@ class IOS(Device):
             return frame
 
         self.recorder = ScreenRecorder(
-            save_path, get_frame, mode=mode, fps=fps,
+            save_path, get_frame, fps=fps,
             snapshot_sleep=snapshot_sleep, orientation=orientation)
         self.recorder.stop_time = max_time
         self.recorder.start()

--- a/airtest/core/win/win.py
+++ b/airtest/core/win/win.py
@@ -509,8 +509,8 @@ class Windows(Device):
         hostname = socket.getfqdn()
         return socket.gethostbyname_ex(hostname)[2][0]
 
-    def start_recording(self, max_time=1800, output=None, fps=10, mode="ffmpeg",
-                        snapshot_sleep=0.001, orientation=0):
+    def start_recording(self, max_time=1800, output=None, fps=10,
+                        snapshot_sleep=0.001, orientation=0, *args, **kwargs):
         """
         Start recording the device display
 
@@ -566,7 +566,7 @@ class Windows(Device):
                 save_path = os.path.join(logdir, output)
 
         self.recorder = ScreenRecorder(
-            save_path, self.snapshot, mode=mode, fps=fps,
+            save_path, self.snapshot, fps=fps,
             snapshot_sleep=snapshot_sleep, orientation=orientation)
         self.recorder.stop_time = max_time
         self.recorder.start()

--- a/airtest/core/win/win.py
+++ b/airtest/core/win/win.py
@@ -517,9 +517,8 @@ class Windows(Device):
         Args:
             max_time: maximum screen recording time, default is 1800
             output: ouput file path
-            mode: the backend write video, choose in ["ffmpeg", "cv2"]
+            mode: the backend write video, choose in ["ffmpeg"]
                 ffmpeg: ffmpeg-python backend, higher compression rate.
-                cv2: cv2.VideoWriter backend, more stable.
             fps: frames per second will record
             snapshot_sleep: sleep time for each snapshot.
             orientation: 1: portrait, 2: landscape, 0: rotation.

--- a/airtest/utils/ffmpeg/ffmpeg_setter.py
+++ b/airtest/utils/ffmpeg/ffmpeg_setter.py
@@ -86,7 +86,7 @@ def get_platform_dir():
 def download_file(url, local_path):
     """Downloads a file to the give path."""
     # NOTE the stream=True parameter below
-    print("Downloading %s -> %s"%(url, local_path))
+    print("Downloading and save to %s" % local_path)
     with requests.get(url, stream=True) as req:
         req.raise_for_status()
         with open(local_path, "wb") as file_d:
@@ -96,7 +96,7 @@ def download_file(url, local_path):
                 # if chunk:
                 # sys.stdout.write(".")
                 file_d.write(chunk)
-        print("Download of %s -> %s completed."%(url, local_path))
+        print("Download completed.")
     return local_path
 
 

--- a/airtest/utils/ffmpeg/ffmpeg_setter.py
+++ b/airtest/utils/ffmpeg/ffmpeg_setter.py
@@ -68,7 +68,7 @@ def get_platform_http_zip():
     """Return the download link for the current platform"""
     check_system()
     try:
-        MAIN_SIT = "https://github.com1/zackees/ffmpeg_bins"
+        MAIN_SIT = "https://github.com/zackees/ffmpeg_bins"
         r = requests.get(MAIN_SIT, timeout=10)
         r.raise_for_status()
         return MAIN_SIT + PLATFORM_ZIP_FILES[sys.platform]

--- a/airtest/utils/version.py
+++ b/airtest/utils/version.py
@@ -1,4 +1,4 @@
-__version__ = "1.2.10"
+__version__ = "1.2.10.1"
 
 import os
 import sys

--- a/airtest/utils/version.py
+++ b/airtest/utils/version.py
@@ -1,4 +1,4 @@
-__version__ = "1.2.9"
+__version__ = "1.2.10"
 
 import os
 import sys

--- a/tests/test_ios.py
+++ b/tests/test_ios.py
@@ -277,19 +277,6 @@ class TestIos(unittest.TestCase):
             duration = frame_num/rate
         self.assertEqual(duration >= 10, True)
         
-        #test other params
-        self.ios.start_recording(output="test_cv_10s.mp4", mode="cv2")
-        time.sleep(10+4)
-        self.ios.stop_recording()
-        time.sleep(2)
-        self.assertEqual(os.path.exists("test_cv_10s.mp4"), True)
-        duration = 0
-        cap = cv2.VideoCapture("test_cv_10s.mp4")
-        if cap.isOpened():
-            rate = cap.get(5)
-            frame_num = cap.get(7)
-            duration = frame_num/rate
-        self.assertEqual(duration >= 10, True)
 
 
 if __name__ == '__main__':

--- a/tests/test_win.py
+++ b/tests/test_win.py
@@ -78,20 +78,6 @@ class TestWin(unittest.TestCase):
             frame_num = cap.get(7)
             duration = frame_num/rate
         self.assertEqual(duration >= 10, True)
-        
-        #test other params
-        self.windows.start_recording(output="test_cv_10s.mp4", mode="cv2")
-        time.sleep(10+4)
-        self.windows.stop_recording()
-        time.sleep(2)
-        self.assertEqual(os.path.exists("test_cv_10s.mp4"), True)
-        duration = 0
-        cap = cv2.VideoCapture("test_cv_10s.mp4")
-        if cap.isOpened():
-            rate = cap.get(5)
-            frame_num = cap.get(7)
-            duration = frame_num/rate
-        self.assertEqual(duration >= 10, True)
 
     @classmethod
     def tearDownClass(cls):

--- a/tests/test_win_app.py
+++ b/tests/test_win_app.py
@@ -47,22 +47,6 @@ class TestWin(unittest.TestCase):
             duration = frame_num/rate
         self.assertEqual(duration >= 10, True)
 
-        #test other params
-        self.windows.start_recording(output="test_cv_10s.mp4", mode="cv2")
-        time.sleep(10+4)
-        self.windows.stop_recording()
-        time.sleep(2)
-        self.assertEqual(os.path.exists("test_cv_10s.mp4"), True)
-        duration = 0
-        cap = cv2.VideoCapture("test_cv_10s.mp4")
-        if cap.isOpened():
-            rate = cap.get(5)
-            frame_num = cap.get(7)
-            duration = frame_num/rate
-        self.assertEqual(duration >= 10, True)
-
-
-
     @classmethod
     def tearDownClass(cls):
         cls.windows.app.kill()


### PR DESCRIPTION
去掉了录屏的cv2模式（原本有ffmpeg和cv2两种），因为cv2模式容易出错，效果也不如ffmpeg
然后因为去掉了cv2模式，win/ios的`start_recording` 就无需再有mode参数，只有android需要mode参数