### PR TITLE
V1.2.10.1

### DIFF
--- a/airtest/aircv/screen_recorder.py
+++ b/airtest/aircv/screen_recorder.py
@@ -18,11 +18,25 @@ RECORDER_ORI = {
 }
 
 def resize_by_max(img, max_size=800):
+    if img is None:
+        return np.zeros((max_size, max_size, 3), dtype=np.uint8)
     max_len = max(img.shape[0], img.shape[1])
     if max_len > max_size:
         scale = max_size / max_len
         img = cv2.resize(img, (int(img.shape[1] * scale), int(img.shape[0] * scale)))
     return img
+
+
+def get_max_size(max_size):
+    try:
+        max_size = int(max_size)
+    except:
+        max_size = None
+    else:
+        if max_size <= 0:
+            max_size = None
+    return max_size
+
 
 class FfmpegVidWriter:
     """

--- a/airtest/aircv/screen_recorder.py
+++ b/airtest/aircv/screen_recorder.py
@@ -61,10 +61,6 @@ class VidWriter:
                 .run_async(pipe_stdin=True)
             )
             self.writer = self.process.stdin
-        elif self.mode == "cv2":
-            fourcc = cv2.VideoWriter_fourcc('m', 'p', '4', 'v')
-            self.writer = cv2.VideoWriter(
-                outfile, fourcc, self.fps, (width, height))
 
     def process_frame(self, frame):
         assert len(frame.shape) == 3
@@ -90,8 +86,6 @@ class VidWriter:
             self.writer.close()
             self.process.wait()
             self.process.terminate()
-        elif self.mode == "cv2":
-            self.writer.release()
 
 
 class ScreenRecorder:

--- a/airtest/aircv/screen_recorder.py
+++ b/airtest/aircv/screen_recorder.py
@@ -17,6 +17,12 @@ RECORDER_ORI = {
     "ROTATION": 0,  # The screen is centered in a square
 }
 
+def resize_by_max(img, max_size=800):
+    max_len = max(img.shape[0], img.shape[1])
+    if max_len > max_size:
+        scale = max_size / max_len
+        img = cv2.resize(img, (int(img.shape[1] * scale), int(img.shape[0] * scale)))
+    return img
 
 class FfmpegVidWriter:
     """

--- a/airtest/core/android/adb.py
+++ b/airtest/core/android/adb.py
@@ -1114,6 +1114,12 @@ class ADB(object):
         if m:
             return int(m.group(1))
 
+        displayFramesRE = re.compile(r"DisplayFrames.*r=(\d+)")
+        output = self.shell('dumpsys window displays')
+        m = displayFramesRE.search(output)
+        if m:
+            return int(m.group(1))
+
         # We couldn't obtain the orientation
         warnings.warn("Could not obtain the orientation, return 0")
         return 0

--- a/airtest/core/android/android.py
+++ b/airtest/core/android/android.py
@@ -825,6 +825,10 @@ class Android(Device):
             >>> # the screen is landscape
             >>> landscape_mp4 = dev.start_recording(output="landscape.mp4", orientation=2)  # or orientation="landscape"
 
+            In yosemite mode, you can specify max_size to limit the video's maximum width/length. Smaller video sizes result in lower CPU load.
+
+            >>> dev.start_recording(output="test.mp4", mode="ffmpeg", max_size=800)
+
         """
         logdir = "./"
         if ST.LOG_DIR is not None:

--- a/airtest/core/android/android.py
+++ b/airtest/core/android/android.py
@@ -794,14 +794,15 @@ class Android(Device):
             max_time: maximum screen recording time, default is 1800
             output: ouput file path
             mode: the backend write video, choose in ["ffmpeg", "yosemite"]
-                yosemite: yosemite backend, higher quality.
-                ffmpeg: ffmpeg-python backend, higher compression rate.
+                yosemite: (default method) High clarity but large file size and limited phone compatibility.
+                ffmpeg: Lower image quality but smaller files and better compatibility.
             fps: frames per second will record
-            snapshot_sleep: sleep time for each snapshot.
+            snapshot_sleep: (mode="ffmpeg" only) sleep time for each snapshot.
             orientation: 1: portrait, 2: landscape, 0: rotation, default is 0
-            bit_rate_level: bit_rate=resolution*level, 0 < level <= 5, default is 1
-            bit_rate: the higher the bitrate, the clearer the video
-            max_size: max size of the video frame, e.g.800, default is None. Smaller sizes lead to lower system load.
+            bit_rate_level: (mode="yosemite" only) bit_rate=resolution*level, 0 < level <= 5, default is 1
+            bit_rate: (mode="yosemite" only) the higher the bitrate, the clearer the video
+            max_size: (mode="ffmpeg" only) max size of the video frame, e.g.800, default is None.
+                      Smaller sizes lead to lower system load.
 
         Returns:
             save_path: path of video file

--- a/airtest/core/android/android.py
+++ b/airtest/core/android/android.py
@@ -25,7 +25,7 @@ from airtest.core.android.touch_methods.minitouch import Minitouch  # noqa
 from airtest.core.android.touch_methods.maxtouch import Maxtouch  # noqa
 
 from airtest.core.settings import Settings as ST
-from airtest.aircv.screen_recorder import ScreenRecorder, resize_by_max
+from airtest.aircv.screen_recorder import ScreenRecorder, resize_by_max, get_max_size
 from airtest.utils.logger import get_logger
 
 LOGGING = get_logger(__name__)
@@ -876,7 +876,8 @@ class Android(Device):
         if self.recorder and self.recorder.is_running():
             LOGGING.warning("recording is already running, please don't call again")
             return None
-        
+
+        max_size = get_max_size(max_size)
         def get_frame():
             data = self.screen_proxy.get_frame_from_stream()
             frame = aircv.utils.string_2_img(data)

--- a/airtest/core/android/android.py
+++ b/airtest/core/android/android.py
@@ -877,7 +877,7 @@ class Android(Device):
             return frame
 
         self.recorder = ScreenRecorder(
-            save_path, get_frame, mode=mode, fps=fps,
+            save_path, get_frame, fps=fps,
             snapshot_sleep=snapshot_sleep, orientation=orientation)
         self.recorder.stop_time = max_time
         self.recorder.start()

--- a/airtest/core/android/android.py
+++ b/airtest/core/android/android.py
@@ -792,10 +792,9 @@ class Android(Device):
         Args:
             max_time: maximum screen recording time, default is 1800
             output: ouput file path
-            mode: the backend write video, choose in ["ffmpeg", "cv2"]
+            mode: the backend write video, choose in ["ffmpeg", "yosemite"]
                 yosemite: yosemite backend, higher quality.
                 ffmpeg: ffmpeg-python backend, higher compression rate.
-                cv2: cv2.VideoWriter backend, more stable.
             fps: frames per second will record
             snapshot_sleep: sleep time for each snapshot.
             orientation: 1: portrait, 2: landscape, 0: rotation, default is 0

--- a/airtest/core/android/android.py
+++ b/airtest/core/android/android.py
@@ -25,7 +25,7 @@ from airtest.core.android.touch_methods.minitouch import Minitouch  # noqa
 from airtest.core.android.touch_methods.maxtouch import Maxtouch  # noqa
 
 from airtest.core.settings import Settings as ST
-from airtest.aircv.screen_recorder import ScreenRecorder
+from airtest.aircv.screen_recorder import ScreenRecorder, resize_by_max
 from airtest.utils.logger import get_logger
 
 LOGGING = get_logger(__name__)
@@ -785,7 +785,8 @@ class Android(Device):
         return x, y, w, h
 
     def start_recording(self, max_time=1800, output=None, fps=10, mode="yosemite",
-                        snapshot_sleep=0.001, orientation=0, bit_rate_level=None, bit_rate=None):
+                        snapshot_sleep=0.001, orientation=0, bit_rate_level=None, 
+                        bit_rate=None, max_size=None):
         """
         Start recording the device display
 
@@ -800,13 +801,14 @@ class Android(Device):
             orientation: 1: portrait, 2: landscape, 0: rotation, default is 0
             bit_rate_level: bit_rate=resolution*level, 0 < level <= 5, default is 1
             bit_rate: the higher the bitrate, the clearer the video
+            max_size: max size of the video frame, e.g.800, default is None. Smaller sizes lead to lower system load.
 
         Returns:
             save_path: path of video file
 
         Examples:
 
-            Record 30 seconds of video and export to the current directory test.mp4::
+            Record 30 seconds of video and export to the current directory test.mp4:
 
             >>> from airtest.core.api import connect_device, sleep
             >>> dev = connect_device("Android:///")
@@ -874,6 +876,9 @@ class Android(Device):
         def get_frame():
             data = self.screen_proxy.get_frame_from_stream()
             frame = aircv.utils.string_2_img(data)
+            
+            if max_size is not None:
+                frame = resize_by_max(frame, max_size)
             return frame
 
         self.recorder = ScreenRecorder(

--- a/airtest/core/android/android.py
+++ b/airtest/core/android/android.py
@@ -786,7 +786,7 @@ class Android(Device):
 
     def start_recording(self, max_time=1800, output=None, fps=10, mode="yosemite",
                         snapshot_sleep=0.001, orientation=0, bit_rate_level=None, 
-                        bit_rate=None, max_size=None):
+                        bit_rate=None, max_size=None, *args, **kwargs):
         """
         Start recording the device display
 
@@ -825,7 +825,7 @@ class Android(Device):
             >>> # the screen is landscape
             >>> landscape_mp4 = dev.start_recording(output="landscape.mp4", orientation=2)  # or orientation="landscape"
 
-            In yosemite mode, you can specify max_size to limit the video's maximum width/length. Smaller video sizes result in lower CPU load.
+            In ffmpeg mode, you can specify max_size to limit the video's maximum width/length. Smaller video sizes result in lower CPU load.
 
             >>> dev.start_recording(output="test.mp4", mode="ffmpeg", max_size=800)
 
@@ -836,12 +836,9 @@ class Android(Device):
         if output is None:
             save_path = os.path.join(logdir, "screen_%s.mp4" % (time.strftime("%Y%m%d%H%M%S", time.localtime())))
         else:
-            if os.path.isabs(output):
-                save_path = output
-            else:
-                save_path = os.path.join(logdir, output)
+            save_path = output if os.path.isabs(output) else os.path.join(logdir, output)
         self.recorder_save_path = save_path
-        
+
         if mode == "yosemite":
             if self.yosemite_recorder.recording_proc != None:
                 LOGGING.warning(
@@ -853,7 +850,7 @@ class Android(Device):
                 if bit_rate_level > 5:
                     bit_rate_level = 5
                 bit_rate = self.display_info['width'] * \
-                    self.display_info['height'] * bit_rate_level
+                        self.display_info['height'] * bit_rate_level
 
             if orientation == 1:
                 bool_is_vertical = "true"
@@ -881,7 +878,7 @@ class Android(Device):
         def get_frame():
             data = self.screen_proxy.get_frame_from_stream()
             frame = aircv.utils.string_2_img(data)
-            
+
             if max_size is not None:
                 frame = resize_by_max(frame, max_size)
             return frame

--- a/airtest/core/android/cap_methods/minicap.py
+++ b/airtest/core/android/cap_methods/minicap.py
@@ -235,6 +235,7 @@ class Minicap(BaseCap):
     @threadsafe_generator
     @on_method_ready('install_or_upgrade')
     def _get_stream(self, lazy=True):
+        self._cleanup_minicap()
         proc, nbsp, localport = self._setup_stream_server(lazy=lazy)
         s = SafeSocket()
         s.connect((self.adb.host, localport))
@@ -381,6 +382,23 @@ class Minicap(BaseCap):
         """
         LOGGING.debug("update_rotation: %s" % rotation)
         self._update_rotation_event.set()
+
+    def _cleanup_minicap(self):
+        """
+        Clean up the minicap process whose status is __skb_wait_for_more_packets
+        清理状态为__skb_wait_for_more_packets的minicap进程
+
+        Returns:
+
+        """
+        # 卡住的进程状态
+        TASK_INTERRUPTIBLE = "__skb_wait_for_more_packets"
+
+        shell_output = self.adb.shell("ps -A| grep minicap")
+        for line in shell_output.split("\r\n"):
+            if TASK_INTERRUPTIBLE in line:
+                pid = line.split()[1]
+                self.adb.shell("kill %s" % pid)
 
     def _cleanup(self):
         """

--- a/airtest/core/android/cap_methods/minicap.py
+++ b/airtest/core/android/cap_methods/minicap.py
@@ -394,11 +394,17 @@ class Minicap(BaseCap):
         # 卡住的进程状态
         TASK_INTERRUPTIBLE = "__skb_wait_for_more_packets"
 
-        shell_output = self.adb.shell("ps -A| grep minicap")
-        for line in shell_output.split("\r\n"):
-            if TASK_INTERRUPTIBLE in line:
-                pid = line.split()[1]
-                self.adb.shell("kill %s" % pid)
+        try:
+            shell_output = self.adb.shell("ps -A| grep minicap")
+        except:
+            pass
+        else:
+            if len(shell_output) == 0:
+                return
+            for line in shell_output.split("\r\n"):
+                if TASK_INTERRUPTIBLE in line:
+                    pid = line.split()[1]
+                    self.adb.shell("kill %s" % pid)
 
     def _cleanup(self):
         """

--- a/airtest/core/ios/ios.py
+++ b/airtest/core/ios/ios.py
@@ -884,6 +884,10 @@ class IOS(Device):
             >>> # the screen is landscape
             >>> landscape_mp4 = dev.start_recording(output="landscape.mp4", orientation=2)  # or orientation="landscape"
 
+            You can specify max_size to limit the video's maximum width/length. Smaller video sizes result in lower CPU load.
+
+            >>> dev.start_recording(output="test.mp4", max_size=800)
+
         """
         if fps > 10 or fps < 1:
             LOGGING.warning("fps should be between 1 and 10, becuase of the recording effiency")

--- a/airtest/core/ios/ios.py
+++ b/airtest/core/ios/ios.py
@@ -18,7 +18,7 @@ from airtest.core.ios.instruct_cmd import InstructHelper
 from airtest.utils.logger import get_logger
 from airtest.core.ios.mjpeg_cap import MJpegcap
 from airtest.core.settings import Settings as ST
-from airtest.aircv.screen_recorder import ScreenRecorder, resize_by_max
+from airtest.aircv.screen_recorder import ScreenRecorder, resize_by_max, get_max_size
 
 LOGGING = get_logger(__name__)
 
@@ -911,6 +911,7 @@ class IOS(Device):
             else:
                 save_path = os.path.join(logdir, output)
 
+        max_size = get_max_size(max_size)
         def get_frame():
             data = self.get_frame_from_stream()
             frame = aircv.utils.string_2_img(data)

--- a/airtest/core/ios/ios.py
+++ b/airtest/core/ios/ios.py
@@ -857,9 +857,8 @@ class IOS(Device):
         Args:
             max_time: maximum screen recording time, default is 1800
             output: ouput file path
-            mode: the backend write video, choose in ["ffmpeg", "cv2"]
+            mode: the backend write video, choose in ["ffmpeg"]
                 ffmpeg: ffmpeg-python backend, higher compression rate.
-                cv2: cv2.VideoWriter backend, more stable.
             fps: frames per second will record
             snapshot_sleep: sleep time for each snapshot.
             orientation: 1: portrait, 2: landscape, 0: rotation, default is 0

--- a/airtest/core/ios/ios.py
+++ b/airtest/core/ios/ios.py
@@ -849,16 +849,14 @@ class IOS(Device):
         if self.rotation_watcher:
             self.rotation_watcher.teardown()
     
-    def start_recording(self, max_time=1800, output=None, fps=10, mode="ffmpeg",
-                        snapshot_sleep=0.001, orientation=0):
+    def start_recording(self, max_time=1800, output=None, fps=10,
+                        snapshot_sleep=0.001, orientation=0, *args, **kwargs):
         """
         Start recording the device display
 
         Args:
             max_time: maximum screen recording time, default is 1800
             output: ouput file path
-            mode: the backend write video, choose in ["ffmpeg"]
-                ffmpeg: ffmpeg-python backend, higher compression rate.
             fps: frames per second will record
             snapshot_sleep: sleep time for each snapshot.
             orientation: 1: portrait, 2: landscape, 0: rotation, default is 0
@@ -914,7 +912,7 @@ class IOS(Device):
             return frame
 
         self.recorder = ScreenRecorder(
-            save_path, get_frame, mode=mode, fps=fps,
+            save_path, get_frame, fps=fps,
             snapshot_sleep=snapshot_sleep, orientation=orientation)
         self.recorder.stop_time = max_time
         self.recorder.start()

--- a/airtest/core/ios/ios.py
+++ b/airtest/core/ios/ios.py
@@ -18,7 +18,7 @@ from airtest.core.ios.instruct_cmd import InstructHelper
 from airtest.utils.logger import get_logger
 from airtest.core.ios.mjpeg_cap import MJpegcap
 from airtest.core.settings import Settings as ST
-from airtest.aircv.screen_recorder import ScreenRecorder
+from airtest.aircv.screen_recorder import ScreenRecorder, resize_by_max
 
 LOGGING = get_logger(__name__)
 
@@ -850,7 +850,7 @@ class IOS(Device):
             self.rotation_watcher.teardown()
     
     def start_recording(self, max_time=1800, output=None, fps=10,
-                        snapshot_sleep=0.001, orientation=0, *args, **kwargs):
+                        snapshot_sleep=0.001, orientation=0, max_size=None, *args, **kwargs):
         """
         Start recording the device display
 
@@ -860,13 +860,14 @@ class IOS(Device):
             fps: frames per second will record
             snapshot_sleep: sleep time for each snapshot.
             orientation: 1: portrait, 2: landscape, 0: rotation, default is 0
+            max_size: max size of the video frame, e.g.800, default is None. Smaller sizes lead to lower system load.
 
         Returns:
             save_path: path of video file
 
         Examples:
 
-            Record 30 seconds of video and export to the current directory test.mp4::
+            Record 30 seconds of video and export to the current directory test.mp4:
 
             >>> from airtest.core.api import connect_device, sleep
             >>> dev = connect_device("IOS:///")
@@ -909,6 +910,9 @@ class IOS(Device):
         def get_frame():
             data = self.get_frame_from_stream()
             frame = aircv.utils.string_2_img(data)
+            
+            if max_size is not None:
+                frame = resize_by_max(frame, max_size)
             return frame
 
         self.recorder = ScreenRecorder(

--- a/airtest/core/win/win.py
+++ b/airtest/core/win/win.py
@@ -509,8 +509,8 @@ class Windows(Device):
         hostname = socket.getfqdn()
         return socket.gethostbyname_ex(hostname)[2][0]
 
-    def start_recording(self, max_time=1800, output=None, fps=10, mode="ffmpeg",
-                        snapshot_sleep=0.001, orientation=0):
+    def start_recording(self, max_time=1800, output=None, fps=10,
+                        snapshot_sleep=0.001, orientation=0, *args, **kwargs):
         """
         Start recording the device display
 
@@ -566,7 +566,7 @@ class Windows(Device):
                 save_path = os.path.join(logdir, output)
 
         self.recorder = ScreenRecorder(
-            save_path, self.snapshot, mode=mode, fps=fps,
+            save_path, self.snapshot, fps=fps,
             snapshot_sleep=snapshot_sleep, orientation=orientation)
         self.recorder.stop_time = max_time
         self.recorder.start()

--- a/airtest/core/win/win.py
+++ b/airtest/core/win/win.py
@@ -18,7 +18,7 @@ from pywinauto.win32functions import SetForegroundWindow
 from airtest.core.win.ctypesinput import key_press, key_release
 
 from airtest import aircv
-from airtest.aircv.screen_recorder import ScreenRecorder, resize_by_max
+from airtest.aircv.screen_recorder import ScreenRecorder, resize_by_max, get_max_size
 from airtest.core.device import Device
 from airtest.core.settings import Settings as ST
 from airtest.utils.logger import get_logger
@@ -569,14 +569,14 @@ class Windows(Device):
                 save_path = output
             else:
                 save_path = os.path.join(logdir, output)
-        
+
+        max_size = get_max_size(max_size)
         def get_frame():
             frame = self.snapshot()
             
             if max_size is not None:
                 frame = resize_by_max(frame, max_size)
             return frame
-            
 
         self.recorder = ScreenRecorder(
             save_path, get_frame, fps=fps,

--- a/airtest/core/win/win.py
+++ b/airtest/core/win/win.py
@@ -538,6 +538,10 @@ class Windows(Device):
             >>> dev.stop_recording()
             >>> print(save_path)
 
+            You can specify max_size to limit the video's maximum width/length. Smaller video sizes result in lower CPU load.
+
+            >>> dev.start_recording(output="test.mp4", max_size=800)
+
         Note:
             1 Don't resize the app window duraing recording, the recording region will be limited by first frame.
             2 If recording still working after app crash, it will continuing write last frame before the crash. 

--- a/airtest/core/win/win.py
+++ b/airtest/core/win/win.py
@@ -18,7 +18,7 @@ from pywinauto.win32functions import SetForegroundWindow
 from airtest.core.win.ctypesinput import key_press, key_release
 
 from airtest import aircv
-from airtest.aircv.screen_recorder import ScreenRecorder
+from airtest.aircv.screen_recorder import ScreenRecorder, resize_by_max
 from airtest.core.device import Device
 from airtest.core.settings import Settings as ST
 from airtest.utils.logger import get_logger
@@ -510,7 +510,7 @@ class Windows(Device):
         return socket.gethostbyname_ex(hostname)[2][0]
 
     def start_recording(self, max_time=1800, output=None, fps=10,
-                        snapshot_sleep=0.001, orientation=0, *args, **kwargs):
+                        snapshot_sleep=0.001, orientation=0, max_size=None, *args, **kwargs):
         """
         Start recording the device display
 
@@ -522,13 +522,14 @@ class Windows(Device):
             fps: frames per second will record
             snapshot_sleep: sleep time for each snapshot.
             orientation: 1: portrait, 2: landscape, 0: rotation.
+            max_size: max size of the video frame, e.g.800, default is None. Smaller sizes lead to lower system load.
 
         Returns:
             save_path: path of video file
 
         Examples:
 
-            Record 30 seconds of video and export to the current directory test.mp4::
+            Record 30 seconds of video and export to the current directory test.mp4:
 
             >>> from airtest.core.api import connect_device, sleep
             >>> dev = connect_device("Windows:///")
@@ -564,9 +565,17 @@ class Windows(Device):
                 save_path = output
             else:
                 save_path = os.path.join(logdir, output)
+        
+        def get_frame():
+            frame = self.snapshot()
+            
+            if max_size is not None:
+                frame = resize_by_max(frame, max_size)
+            return frame
+            
 
         self.recorder = ScreenRecorder(
-            save_path, self.snapshot, fps=fps,
+            save_path, get_frame, fps=fps,
             snapshot_sleep=snapshot_sleep, orientation=orientation)
         self.recorder.stop_time = max_time
         self.recorder.start()

--- a/airtest/core/win/win.py
+++ b/airtest/core/win/win.py
@@ -517,9 +517,8 @@ class Windows(Device):
         Args:
             max_time: maximum screen recording time, default is 1800
             output: ouput file path
-            mode: the backend write video, choose in ["ffmpeg", "cv2"]
+            mode: the backend write video, choose in ["ffmpeg"]
                 ffmpeg: ffmpeg-python backend, higher compression rate.
-                cv2: cv2.VideoWriter backend, more stable.
             fps: frames per second will record
             snapshot_sleep: sleep time for each snapshot.
             orientation: 1: portrait, 2: landscape, 0: rotation.

--- a/airtest/utils/ffmpeg/ffmpeg_setter.py
+++ b/airtest/utils/ffmpeg/ffmpeg_setter.py
@@ -86,7 +86,7 @@ def get_platform_dir():
 def download_file(url, local_path):
     """Downloads a file to the give path."""
     # NOTE the stream=True parameter below
-    print("Downloading %s -> %s"%(url, local_path))
+    print("Downloading and save to %s" % local_path)
     with requests.get(url, stream=True) as req:
         req.raise_for_status()
         with open(local_path, "wb") as file_d:
@@ -96,7 +96,7 @@ def download_file(url, local_path):
                 # if chunk:
                 # sys.stdout.write(".")
                 file_d.write(chunk)
-        print("Download of %s -> %s completed."%(url, local_path))
+        print("Download completed.")
     return local_path
 
 

--- a/airtest/utils/ffmpeg/ffmpeg_setter.py
+++ b/airtest/utils/ffmpeg/ffmpeg_setter.py
@@ -68,7 +68,7 @@ def get_platform_http_zip():
     """Return the download link for the current platform"""
     check_system()
     try:
-        MAIN_SIT = "https://github.com1/zackees/ffmpeg_bins"
+        MAIN_SIT = "https://github.com/zackees/ffmpeg_bins"
         r = requests.get(MAIN_SIT, timeout=10)
         r.raise_for_status()
         return MAIN_SIT + PLATFORM_ZIP_FILES[sys.platform]

--- a/airtest/utils/version.py
+++ b/airtest/utils/version.py
@@ -1,4 +1,4 @@
-__version__ = "1.2.10.1"
+__version__ = "1.2.10.2"
 
 import os
 import sys

--- a/airtest/utils/version.py
+++ b/airtest/utils/version.py
@@ -1,4 +1,4 @@
-__version__ = "1.2.10"
+__version__ = "1.2.10.1"
 
 import os
 import sys

--- a/airtest/utils/version.py
+++ b/airtest/utils/version.py
@@ -1,4 +1,4 @@
-__version__ = "1.2.9"
+__version__ = "1.2.10"
 
 import os
 import sys

--- a/tests/test_android_recorder.py
+++ b/tests/test_android_recorder.py
@@ -78,3 +78,56 @@ class TestAndroidRecorder(unittest.TestCase):
         self.android.recorder.pull_last_recording_file()
         self.assertTrue(os.path.exists(self.filepath))
 
+
+class TestAndroidFfmpegRecorder(unittest.TestCase):
+    """Test Android ffmpeg screen recording function"""
+    @classmethod
+    def setUpClass(cls):
+        from airtest.core.api import connect_device
+        cls.android = connect_device("android://10.227.71.87:5039/0715f753568a0634")
+        # cls.android = Android()
+
+    def tearDown(self):
+        try_remove("screen.mp4")
+
+    def test_recording(self):
+        save_path = self.android.start_recording(mode='ffmpeg', output="screen.mp4", max_time=10)
+        time.sleep(10)
+        self.android.stop_recording()
+        self.assertTrue(os.path.exists(save_path))
+
+    def test_maxsize(self):
+        save_path = self.android.start_recording(mode='ffmpeg', output="screen.mp4", max_time=10, max_size=720)
+        time.sleep(10)
+        self.android.stop_recording()
+        self.assertTrue(os.path.exists(save_path))
+
+    def test_maxsize_error(self):
+        for maxsize in [0, "test", "800*600"]:
+            save_path = self.android.start_recording(mode='ffmpeg', output="screen.mp4", max_time=10, max_size=maxsize)
+            time.sleep(10)
+            self.android.stop_recording()
+            self.assertTrue(os.path.exists(save_path))
+            try_remove(save_path)
+
+    def test_ori(self):
+        for ori in ["portrait", 1, "landscape", 2, 0]:
+            save_path = self.android.start_recording(mode='ffmpeg', output="screen.mp4", orientation=ori)
+            time.sleep(10)
+            self.android.stop_recording()
+            self.assertTrue(os.path.exists(save_path))
+
+    def test_ori_error(self):
+        # 当orientation不合法时，会自动使用0，即方形录制
+        for ori in ["p", "1"]:
+            save_path = self.android.start_recording(mode='ffmpeg', output="screen.mp4", orientation=ori)
+            time.sleep(10)
+            self.android.stop_recording()
+            self.assertTrue(os.path.exists(save_path))
+
+    def test_fps(self):
+        for fps in [1, 10, 30, 60]:
+            save_path = self.android.start_recording(mode='ffmpeg', output="screen.mp4", fps=fps)
+            time.sleep(10)
+            self.android.stop_recording()
+            self.assertTrue(os.path.exists(save_path))

--- a/tests/test_android_recorder.py
+++ b/tests/test_android_recorder.py
@@ -83,9 +83,7 @@ class TestAndroidFfmpegRecorder(unittest.TestCase):
     """Test Android ffmpeg screen recording function"""
     @classmethod
     def setUpClass(cls):
-        from airtest.core.api import connect_device
-        cls.android = connect_device("android://10.227.71.87:5039/0715f753568a0634")
-        # cls.android = Android()
+        cls.android = Android()
 
     def tearDown(self):
         try_remove("screen.mp4")

--- a/tests/test_ios.py
+++ b/tests/test_ios.py
@@ -277,19 +277,6 @@ class TestIos(unittest.TestCase):
             duration = frame_num/rate
         self.assertEqual(duration >= 10, True)
         
-        #test other params
-        self.ios.start_recording(output="test_cv_10s.mp4", mode="cv2")
-        time.sleep(10+4)
-        self.ios.stop_recording()
-        time.sleep(2)
-        self.assertEqual(os.path.exists("test_cv_10s.mp4"), True)
-        duration = 0
-        cap = cv2.VideoCapture("test_cv_10s.mp4")
-        if cap.isOpened():
-            rate = cap.get(5)
-            frame_num = cap.get(7)
-            duration = frame_num/rate
-        self.assertEqual(duration >= 10, True)
 
 
 if __name__ == '__main__':

--- a/tests/test_win.py
+++ b/tests/test_win.py
@@ -78,20 +78,6 @@ class TestWin(unittest.TestCase):
             frame_num = cap.get(7)
             duration = frame_num/rate
         self.assertEqual(duration >= 10, True)
-        
-        #test other params
-        self.windows.start_recording(output="test_cv_10s.mp4", mode="cv2")
-        time.sleep(10+4)
-        self.windows.stop_recording()
-        time.sleep(2)
-        self.assertEqual(os.path.exists("test_cv_10s.mp4"), True)
-        duration = 0
-        cap = cv2.VideoCapture("test_cv_10s.mp4")
-        if cap.isOpened():
-            rate = cap.get(5)
-            frame_num = cap.get(7)
-            duration = frame_num/rate
-        self.assertEqual(duration >= 10, True)
 
     @classmethod
     def tearDownClass(cls):

--- a/tests/test_win_app.py
+++ b/tests/test_win_app.py
@@ -47,22 +47,6 @@ class TestWin(unittest.TestCase):
             duration = frame_num/rate
         self.assertEqual(duration >= 10, True)
 
-        #test other params
-        self.windows.start_recording(output="test_cv_10s.mp4", mode="cv2")
-        time.sleep(10+4)
-        self.windows.stop_recording()
-        time.sleep(2)
-        self.assertEqual(os.path.exists("test_cv_10s.mp4"), True)
-        duration = 0
-        cap = cv2.VideoCapture("test_cv_10s.mp4")
-        if cap.isOpened():
-            rate = cap.get(5)
-            frame_num = cap.get(7)
-            duration = frame_num/rate
-        self.assertEqual(duration >= 10, True)
-
-
-
     @classmethod
     def tearDownClass(cls):
         cls.windows.app.kill()


### PR DESCRIPTION
1. 去掉了录屏的cv2模式（原本有ffmpeg和cv2两种），因为cv2模式容易出错，效果也不如ffmpeg
    - 然后因为去掉了cv2模式，win/ios的start_recording 就无需再有mode参数，只有android需要mode参数
2.  录屏的ffmpeg模式增加了max_size参数，能够指定录屏结果的图像大小，因为屏幕图片越大，在录屏时造成的系统负载越大（CPU和内存占用）
3. 增加了android的ffmpeg录屏的相关testcase
4. minicap在创建连接时，自动杀掉之前残留的状态为`__skb_wait_for_more_packets`的minicap进程，因为这种类型的进程可能导致屏幕有一半是黑屏