### PR TITLE
Device absent error handling

### DIFF
--- a/airtest/core/cv.py
+++ b/airtest/core/cv.py
@@ -12,9 +12,9 @@ from copy import deepcopy
 
 from airtest import aircv
 from airtest.aircv import cv2
-from airtest.core.helper import G, logwrap
+from airtest.core.helper import G, logwrap, ensure_device
 from airtest.core.settings import Settings as ST  # noqa
-from airtest.core.error import TargetNotFoundError, InvalidMatchingMethodError, NoDeviceError
+from airtest.core.error import TargetNotFoundError, InvalidMatchingMethodError
 from airtest.utils.transform import TargetPos
 
 from airtest.aircv.template_matching import TemplateMatching
@@ -37,6 +37,7 @@ MATCHING_METHODS = {
 
 
 @logwrap
+@ensure_device
 def loop_find(query, timeout=ST.FIND_TIMEOUT, threshold=None, interval=0.5, intervalfunc=None):
     """
     Search for image template in the screen until timeout
@@ -56,10 +57,6 @@ def loop_find(query, timeout=ST.FIND_TIMEOUT, threshold=None, interval=0.5, inte
         been found in screenshot
 
     """
-
-    if G.DEVICE is None:
-        raise NoDeviceError("No devices added / connected.")
-
     G.LOGGING.info("Try finding: %s", query)
     start_time = time.time()
     while True:

--- a/airtest/core/cv.py
+++ b/airtest/core/cv.py
@@ -84,6 +84,7 @@ def loop_find(query, timeout=ST.FIND_TIMEOUT, threshold=None, interval=0.5, inte
 
 
 @logwrap
+@ensure_device
 def try_log_screen(screen=None, quality=None, max_size=None):
     """
     Save screenshot to file

--- a/airtest/core/cv.py
+++ b/airtest/core/cv.py
@@ -12,7 +12,7 @@ from copy import deepcopy
 
 from airtest import aircv
 from airtest.aircv import cv2
-from airtest.core.helper import G, logwrap, ensure_device
+from airtest.core.helper import G, logwrap
 from airtest.core.settings import Settings as ST  # noqa
 from airtest.core.error import TargetNotFoundError, InvalidMatchingMethodError
 from airtest.utils.transform import TargetPos
@@ -37,7 +37,6 @@ MATCHING_METHODS = {
 
 
 @logwrap
-@ensure_device
 def loop_find(query, timeout=ST.FIND_TIMEOUT, threshold=None, interval=0.5, intervalfunc=None):
     """
     Search for image template in the screen until timeout
@@ -84,7 +83,6 @@ def loop_find(query, timeout=ST.FIND_TIMEOUT, threshold=None, interval=0.5, inte
 
 
 @logwrap
-@ensure_device
 def try_log_screen(screen=None, quality=None, max_size=None):
     """
     Save screenshot to file

--- a/airtest/core/cv.py
+++ b/airtest/core/cv.py
@@ -14,7 +14,7 @@ from airtest import aircv
 from airtest.aircv import cv2
 from airtest.core.helper import G, logwrap
 from airtest.core.settings import Settings as ST  # noqa
-from airtest.core.error import TargetNotFoundError, InvalidMatchingMethodError
+from airtest.core.error import TargetNotFoundError, InvalidMatchingMethodError, NoDeviceError
 from airtest.utils.transform import TargetPos
 
 from airtest.aircv.template_matching import TemplateMatching
@@ -56,6 +56,10 @@ def loop_find(query, timeout=ST.FIND_TIMEOUT, threshold=None, interval=0.5, inte
         been found in screenshot
 
     """
+
+    if G.DEVICE is None:
+        raise NoDeviceError("No devices added / connected.")
+
     G.LOGGING.info("Try finding: %s", query)
     start_time = time.time()
     while True:

--- a/airtest/core/error.py
+++ b/airtest/core/error.py
@@ -71,6 +71,9 @@ class DeviceConnectionError(BaseError):
     pass
 
 class NoDeviceError(BaseError):
+    """
+        When no device is connected
+    """
     pass
 
 

--- a/airtest/core/error.py
+++ b/airtest/core/error.py
@@ -70,6 +70,9 @@ class DeviceConnectionError(BaseError):
     DEVICE_CONNECTION_ERROR = r"error:\s*((device \'\S+\' not found)|(cannot connect to daemon at [\w\:\s\.]+ Connection timed out))"
     pass
 
+class NoDeviceError(BaseError):
+    pass
+
 
 class ICmdError(Exception):
     """

--- a/airtest/core/helper.py
+++ b/airtest/core/helper.py
@@ -8,22 +8,30 @@ import traceback
 from airtest.core.settings import Settings as ST
 from airtest.utils.logger import get_logger
 from airtest.utils.logwraper import Logwrap, AirtestLogger
+from airtest.core.error import NoDeviceError
 
-def ensure_device(func):
-    @functools.wraps(func)
-    def wrapper(*args, **kwargs):
-        if G.DEVICE is None:
+
+class DeviceMetaProperty(type):
+
+    @property
+    def DEVICE(cls):
+        if G._DEVICE is None:
             raise NoDeviceError("No devices added.")
-        return func(*args, **kwargs)
-    return wrapper
+        return G._DEVICE
 
-class G(object):
+    @DEVICE.setter
+    def DEVICE(self, dev):
+        self._DEVICE = dev
+        self.LOGGING.debug("Set current device to: %s" % dev)
+
+
+class G(object, metaclass=DeviceMetaProperty):
     """Represent the globals variables"""
     BASEDIR = []
     LOGGER = AirtestLogger(None)
     LOGGING = get_logger("airtest.core.api")
     SCREEN = None
-    DEVICE = None
+    _DEVICE = None
     DEVICE_LIST = []
     RECENT_CAPTURE = None
     RECENT_CAPTURE_PATH = None

--- a/airtest/core/helper.py
+++ b/airtest/core/helper.py
@@ -1,13 +1,21 @@
 # -*- coding: utf-8 -*-
-import time
-import sys
+import functools
 import os
 import six
+import sys
+import time
 import traceback
 from airtest.core.settings import Settings as ST
-from airtest.utils.logwraper import Logwrap, AirtestLogger
 from airtest.utils.logger import get_logger
+from airtest.utils.logwraper import Logwrap, AirtestLogger
 
+def ensure_device(func):
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        if G.DEVICE is None:
+            raise NoDeviceError("No devices added.")
+        return func(*args, **kwargs)
+    return wrapper
 
 class G(object):
     """Represent the globals variables"""


### PR DESCRIPTION
Provides a decorator to make sure device is present before performing specific tasks. Useful for producing clearer errors.