### PR TITLE
V1.3.1

### DIFF
--- a/airtest/aircv/utils.py
+++ b/airtest/aircv/utils.py
@@ -100,7 +100,7 @@ def compress_image(pil_img, path, quality, max_size=None):
     """
     if max_size:
         # The picture will be saved in a size <= max_size*max_size
-        pil_img.thumbnail((max_size, max_size), Image.ANTIALIAS)
+        pil_img.thumbnail((max_size, max_size), Image.LANCZOS)
     quality = int(round(quality))
     if quality <= 0 or quality >= 100:
         raise Exception("SNAPSHOT_QUALITY (" + str(quality) + ") should be an integer in the range [1,99]")

--- a/airtest/cli/runner.py
+++ b/airtest/cli/runner.py
@@ -71,7 +71,7 @@ class AirtestCase(unittest.TestCase):
         try:
             exec(compile(code.encode("utf-8"), pyfilepath, 'exec'), self.scope)
         except Exception as err:
-            log(err, desc="Final Error", snapshot=True)
+            log(err, desc="Final Error", snapshot=True if G.DEVICE_LIST else False)
             six.reraise(*sys.exc_info())
 
     @classmethod

--- a/airtest/core/android/adb.py
+++ b/airtest/core/android/adb.py
@@ -1421,7 +1421,10 @@ class ADB(object):
 
         """
         if not activity:
-            ret = self.shell(['monkey', '-p', package, '-c', 'android.intent.category.LAUNCHER', '1'])
+            try:
+                ret = self.shell(['monkey', '-p', package, '-c', 'android.intent.category.LAUNCHER', '1'])
+            except AdbShellError as e:
+                raise AirtestError("Starting App: %s Failed! No activities found to run." % package)
             if "No activities found to run" in ret:
                 raise AirtestError("Starting App: %s Failed! No activities found to run." % package)
         else:

--- a/airtest/core/android/adb.py
+++ b/airtest/core/android/adb.py
@@ -584,9 +584,11 @@ class ADB(object):
         try:
             self.cmd(cmds)
         except AdbError as e:
-            # ignore if already removed
-            if "not found" in e.stdout:
+            # ignore if already removed or disconnected
+            if "not found" in (repr(e.stdout) + repr(e.stderr)):
                 pass
+        except DeviceConnectionError:
+            pass
         # unregister for cleanup
         if local in self._forward_local_using:
             self._forward_local_using.remove(local)

--- a/airtest/core/android/adb.py
+++ b/airtest/core/android/adb.py
@@ -5,6 +5,7 @@ import sys
 import time
 import random
 import platform
+import psutil
 import warnings
 import subprocess
 import threading
@@ -36,7 +37,7 @@ class ADB(object):
 
     def __init__(self, serialno=None, adb_path=None, server_addr=None, display_id=None, input_event=None):
         self.serialno = serialno
-        self.adb_path = adb_path or self.builtin_adb_path()
+        self.adb_path = adb_path or self.get_adb_path()
         self.display_id = display_id
         self.input_event = input_event
         self._set_cmd_options(server_addr)
@@ -47,6 +48,42 @@ class ADB(object):
         self._display_info_lock = threading.Lock()
         self._forward_local_using = []
         self.__class__._instances.append(self)
+
+    @staticmethod
+    def get_adb_path():
+        """
+        Returns the path to the adb executable.
+
+        Checks if adb process is running, returns the running process path.
+
+        If adb process is not running, checks if ANDROID_HOME environment variable is set.
+        Constructs the adb path using ANDROID_HOME and returns it if set.
+
+        If adb process is not running and ANDROID_HOME is not set, uses built-in adb path.
+
+        Returns:
+            str: The path to the adb executable.
+        """
+        if platform.system() == "Windows":
+            ADB_NAME = "adb.exe"
+        else:
+            ADB_NAME = "adb"
+
+        # Check if adb process is already running
+        for process in psutil.process_iter(['name', 'exe']):
+            if process.info['name'] == ADB_NAME:
+                return process.info['exe']
+
+        # Check if ANDROID_HOME environment variable exists
+        android_home = os.environ.get('ANDROID_HOME')
+        if android_home:
+            adb_path = os.path.join(android_home, 'platform-tools', ADB_NAME)
+            if os.path.exists(adb_path):
+                return adb_path
+
+        # Use airtest builtin adb path
+        builtin_adb_path = ADB.builtin_adb_path()
+        return builtin_adb_path
 
     @staticmethod
     def builtin_adb_path():
@@ -65,9 +102,6 @@ class ADB(object):
         if not adb_path:
             raise RuntimeError("No adb executable supports this platform({}-{}).".format(system, machine))
 
-        # overwrite uiautomator adb
-        if "ANDROID_HOME" in os.environ:
-            del os.environ["ANDROID_HOME"]
         if system != "Windows":
             # chmod +x adb
             make_file_executable(adb_path)

--- a/airtest/core/android/adb.py
+++ b/airtest/core/android/adb.py
@@ -1387,7 +1387,9 @@ class ADB(object):
 
         """
         if not activity:
-            self.shell(['monkey', '-p', package, '-c', 'android.intent.category.LAUNCHER', '1'])
+            ret = self.shell(['monkey', '-p', package, '-c', 'android.intent.category.LAUNCHER', '1'])
+            if "No activities found to run" in ret:
+                raise AirtestError("Starting App: %s Failed! No activities found to run." % package)
         else:
             self.shell(['am', 'start', '-n', '%s/%s.%s' % (package, package, activity)])
 

--- a/airtest/core/android/android.py
+++ b/airtest/core/android/android.py
@@ -40,9 +40,11 @@ class Android(Device):
                  ime_method=IME_METHOD.YOSEMITEIME,
                  ori_method=ORI_METHOD.MINICAP,
                  display_id=None,
-                 input_event=None):
+                 input_event=None,
+                 name=None):
         super(Android, self).__init__()
         self.serialno = serialno or self.get_default_device()
+        self._uuid = name or self.serialno
         self._cap_method = cap_method.upper()
         self._touch_method = touch_method.upper()
         self.ime_method = ime_method.upper()
@@ -256,7 +258,7 @@ class Android(Device):
 
         :return:
         """
-        ult = [self.serialno]
+        ult = [self._uuid]
         if self.display_id:
             ult.append(self.display_id)
         if self.input_event:

--- a/airtest/core/android/android.py
+++ b/airtest/core/android/android.py
@@ -488,7 +488,7 @@ class Android(Device):
         Input text on the device
 
         Args:
-            text: text to input
+            text: text to input, will automatically replace single quotes with double quotes
             enter: True or False whether to press `Enter` key
             search: True or False whether to press `Search` key on IME after input
 

--- a/airtest/core/android/android.py
+++ b/airtest/core/android/android.py
@@ -42,6 +42,7 @@ class Android(Device):
                  ori_method=ORI_METHOD.MINICAP,
                  display_id=None,
                  input_event=None,
+                 adb_path=None,
                  name=None):
         super(Android, self).__init__()
         self.serialno = serialno or self.get_default_device()
@@ -53,7 +54,7 @@ class Android(Device):
         self.display_id = display_id
         self.input_event = input_event
         # init adb
-        self.adb = ADB(self.serialno, server_addr=host, display_id=self.display_id, input_event=self.input_event)
+        self.adb = ADB(self.serialno, adb_path=adb_path, server_addr=host, display_id=self.display_id, input_event=self.input_event)
         self.adb.wait_for_device()
         self.sdk_version = self.adb.sdk_version
         if self.sdk_version >= SDK_VERISON_ANDROID10 and self._touch_method == TOUCH_METHOD.MINITOUCH:
@@ -241,7 +242,7 @@ class Android(Device):
                       DeprecationWarning)
         return getattr(self, new_name)
 
-    def get_default_device(self):
+    def get_default_device(self, adb_path=None):
         """
         Get local default device when no serialno
 
@@ -249,9 +250,9 @@ class Android(Device):
             local device serialno
 
         """
-        if not ADB().devices(state="device"):
+        if not ADB(adb_path=adb_path).devices(state="device"):
             raise IndexError("ADB devices not found")
-        return ADB().devices(state="device")[0][0]
+        return ADB(adb_path=adb_path).devices(state="device")[0][0]
 
     @property
     def uuid(self):

--- a/airtest/core/android/android.py
+++ b/airtest/core/android/android.py
@@ -942,6 +942,14 @@ class Android(Device):
         """
         self.yosemite_ext.set_clipboard(text)
 
+    def paste(self):
+        """
+        Paste the clipboard content
+        Returns:
+
+        """
+        self.text(self.get_clipboard())
+
     def _register_rotation_watcher(self):
         """
         Register callbacks for Android and minicap when rotation of screen has changed

--- a/airtest/core/android/android.py
+++ b/airtest/core/android/android.py
@@ -8,6 +8,7 @@ from copy import copy
 from airtest import aircv
 from airtest.core.device import Device
 from airtest.core.android.ime import YosemiteIme
+from airtest.core.android.yosemite_ext import YosemiteExt
 from airtest.core.android.constant import CAP_METHOD, TOUCH_METHOD, IME_METHOD, ORI_METHOD, \
     SDK_VERISON_ANDROID10
 from airtest.core.android.adb import ADB
@@ -63,6 +64,7 @@ class Android(Device):
         self.rotation_watcher = RotationWatcher(self.adb, self.ori_method)
         self.yosemite_ime = YosemiteIme(self.adb)
         self.yosemite_recorder = Recorder(self.adb)
+        self.yosemite_ext = YosemiteExt(self.adb)
         self._register_rotation_watcher()
 
         self._touch_proxy = None
@@ -916,6 +918,29 @@ class Android(Device):
             shutil.move(self.recorder_save_path, output)
             LOGGING.info("save video to {}".format(output))
         return True
+
+    def get_clipboard(self):
+        """
+        Get the clipboard content
+
+        Returns:
+            clipboard content
+
+        """
+        return self.yosemite_ext.get_clipboard()
+
+    def set_clipboard(self, text):
+        """
+        Set the clipboard content
+
+        Args:
+            text: text to set
+
+        Returns:
+            None
+
+        """
+        self.yosemite_ext.set_clipboard(text)
 
     def _register_rotation_watcher(self):
         """

--- a/airtest/core/android/cap_methods/minicap.py
+++ b/airtest/core/android/cap_methods/minicap.py
@@ -388,14 +388,15 @@ class Minicap(BaseCap):
 
     def _cleanup_minicap(self):
         """
-        Clean up the minicap process whose status is __skb_wait_for_more_packets
-        清理状态为__skb_wait_for_more_packets的minicap进程
+        Clean up the minicap process whose status is __skb_wait_for_more_packets or futex_wait_queue_me
+        清理状态为__skb_wait_for_more_packets, futex_wait_queue_me的minicap进程
 
         Returns:
 
         """
         # 卡住的进程状态
-        TASK_INTERRUPTIBLE = "__skb_wait_for_more_packets"
+        TASK_INTERRUPTIBLE1 = "__skb_wait_for_more_packets"
+        TASK_INTERRUPTIBLE2 = "futex_wait_queue_me"
 
         try:
             shell_output = self.adb.shell("ps -A| grep minicap")
@@ -405,9 +406,12 @@ class Minicap(BaseCap):
             if len(shell_output) == 0:
                 return
             for line in shell_output.split("\r\n"):
-                if TASK_INTERRUPTIBLE in line:
+                if TASK_INTERRUPTIBLE1 in line or TASK_INTERRUPTIBLE2 in line:
                     pid = line.split()[1]
-                    self.adb.shell("kill %s" % pid)
+                    try:
+                        self.adb.shell("kill %s" % pid)
+                    except:
+                        pass
 
     def _cleanup(self):
         """

--- a/airtest/core/android/ime.py
+++ b/airtest/core/android/ime.py
@@ -2,6 +2,7 @@
 import re
 from airtest.core.android.yosemite import Yosemite
 from airtest.core.error import AdbError
+from airtest.utils.snippet import escape_special_char
 from .constant import YOSEMITE_IME_SERVICE
 from six import text_type
 
@@ -113,7 +114,7 @@ class YosemiteIme(CustomIme):
         Input text with Yosemite input method
 
         Args:
-            value: text to be inputted, will automatically replace single quotes with double quotes
+            value: text to be inputted
 
         Returns:
             output form `adb shell` command
@@ -123,10 +124,8 @@ class YosemiteIme(CustomIme):
             self.start()
         # 更多的输入用法请见 https://github.com/macacajs/android-unicode#use-in-adb-shell
         value = ensure_unicode(value)
-        if '\'' in value:
-            # 如果value中有特殊符号，必须用单引号包裹内容，因此将单引号替换为双引号
-            value = value.replace('\'', '"')
-        self.adb.shell(f"am broadcast -a ADB_INPUT_TEXT --es msg '{value}'")
+        value = escape_special_char(value)
+        self.adb.shell(f"am broadcast -a ADB_INPUT_TEXT --es msg {value}")
 
     def code(self, code):
         """

--- a/airtest/core/android/ime.py
+++ b/airtest/core/android/ime.py
@@ -113,7 +113,7 @@ class YosemiteIme(CustomIme):
         Input text with Yosemite input method
 
         Args:
-            value: text to be inputted
+            value: text to be inputted, will automatically replace single quotes with double quotes
 
         Returns:
             output form `adb shell` command
@@ -124,9 +124,9 @@ class YosemiteIme(CustomIme):
         # 更多的输入用法请见 https://github.com/macacajs/android-unicode#use-in-adb-shell
         value = ensure_unicode(value)
         if '\'' in value:
-            self.adb.shell(f'am broadcast -a ADB_INPUT_TEXT --es msg "{value}"')
-        else:
-            self.adb.shell(f"am broadcast -a ADB_INPUT_TEXT --es msg '{value}'")
+            # 如果value中有特殊符号，必须用单引号包裹内容，因此将单引号替换为双引号
+            value = value.replace('\'', '"')
+        self.adb.shell(f"am broadcast -a ADB_INPUT_TEXT --es msg '{value}'")
 
     def code(self, code):
         """

--- a/airtest/core/android/ime.py
+++ b/airtest/core/android/ime.py
@@ -123,7 +123,7 @@ class YosemiteIme(CustomIme):
             self.start()
         # 更多的输入用法请见 https://github.com/macacajs/android-unicode#use-in-adb-shell
         value = ensure_unicode(value)
-        self.adb.shell(u"am broadcast -a ADB_INPUT_TEXT --es msg '{}'".format(value))
+        self.adb.shell(u'am broadcast -a ADB_INPUT_TEXT --es msg "{}"'.format(value))
 
     def code(self, code):
         """

--- a/airtest/core/android/ime.py
+++ b/airtest/core/android/ime.py
@@ -123,7 +123,10 @@ class YosemiteIme(CustomIme):
             self.start()
         # 更多的输入用法请见 https://github.com/macacajs/android-unicode#use-in-adb-shell
         value = ensure_unicode(value)
-        self.adb.shell(u'am broadcast -a ADB_INPUT_TEXT --es msg "{}"'.format(value))
+        if '\'' in value:
+            self.adb.shell(f'am broadcast -a ADB_INPUT_TEXT --es msg "{value}"')
+        else:
+            self.adb.shell(f"am broadcast -a ADB_INPUT_TEXT --es msg '{value}'")
 
     def code(self, code):
         """

--- a/airtest/core/android/yosemite.py
+++ b/airtest/core/android/yosemite.py
@@ -41,7 +41,7 @@ class Yosemite(object):
             LOGGING.info(
                 "local version code is {}, installed version code is {}".format(apk_version, installed_version))
             try:
-                self.adb.install_app(apk_path, replace=True, install_options=["-t", "-g"])
+                self.adb.pm_install(apk_path, replace=True, install_options=["-t"])
             except:
                 if installed_version is None:
                     raise

--- a/airtest/core/android/yosemite_ext.py
+++ b/airtest/core/android/yosemite_ext.py
@@ -55,6 +55,20 @@ class YosemiteExt(Yosemite):
             None
 
         """
-        ret = self.device_op("clipboard", f"--TEXT {text}")
+        ret = self.device_op("clipboard", f'--TEXT "{text}"')
         if ret and "Exception" in ret:
             raise AirtestError("set clipboard failed: %s" % ret)
+
+    def change_lang(self, lang):
+        """
+        Change language
+
+        Args:
+            lang: language to be set
+
+        Returns:
+            None
+
+        """
+        lang_list = ['zh', 'en', 'fr', 'de', 'it', 'ja', 'ko', ]
+        self.device_op("changeLanguge", f"--LANGUAGE_OP {lang}")

--- a/airtest/core/android/yosemite_ext.py
+++ b/airtest/core/android/yosemite_ext.py
@@ -1,6 +1,7 @@
 from .constant import YOSEMITE_APK, YOSEMITE_PACKAGE
 from airtest.core.android.yosemite import Yosemite
 from airtest.core.error import AirtestError
+from airtest.utils.snippet import on_method_ready
 from airtest.utils.logger import get_logger
 LOGGING = get_logger(__name__)
 
@@ -17,6 +18,7 @@ class YosemiteExt(Yosemite):
             self._path = self.adb.path_app(YOSEMITE_PACKAGE)
         return self._path
 
+    @on_method_ready('install_or_upgrade')
     def device_op(self, op_name, op_args=""):
         """
         Perform device operations
@@ -46,7 +48,7 @@ class YosemiteExt(Yosemite):
 
     def set_clipboard(self, text):
         """
-        Set clipboard content
+        Set clipboard content, will automatically replace single quotes with double quotes
 
         Args:
             text: text to be set
@@ -55,7 +57,9 @@ class YosemiteExt(Yosemite):
             None
 
         """
-        ret = self.device_op("clipboard", f'--TEXT "{text}"')
+        if "\'" in text:
+            text = text.replace("\'", "\"")
+        ret = self.device_op("clipboard", f"--TEXT '{text}'")
         if ret and "Exception" in ret:
             raise AirtestError("set clipboard failed: %s" % ret)
 

--- a/airtest/core/android/yosemite_ext.py
+++ b/airtest/core/android/yosemite_ext.py
@@ -1,7 +1,9 @@
+import re
+
 from .constant import YOSEMITE_APK, YOSEMITE_PACKAGE
 from airtest.core.android.yosemite import Yosemite
 from airtest.core.error import AirtestError
-from airtest.utils.snippet import on_method_ready
+from airtest.utils.snippet import on_method_ready, escape_special_char
 from airtest.utils.logger import get_logger
 LOGGING = get_logger(__name__)
 
@@ -48,7 +50,7 @@ class YosemiteExt(Yosemite):
 
     def set_clipboard(self, text):
         """
-        Set clipboard content, will automatically replace single quotes with double quotes
+        Set clipboard content
 
         Args:
             text: text to be set
@@ -57,11 +59,15 @@ class YosemiteExt(Yosemite):
             None
 
         """
-        if "\'" in text:
-            text = text.replace("\'", "\"")
-        ret = self.device_op("clipboard", f"--TEXT '{text}'")
-        if ret and "Exception" in ret:
-            raise AirtestError("set clipboard failed: %s" % ret)
+        text = escape_special_char(text)
+
+        try:
+            ret = self.device_op("clipboard", f'--TEXT {text}')
+        except Exception as e:
+            raise AirtestError("set clipboard failed, %s" % repr(e))
+        else:
+            if ret and "Exception" in ret:
+                raise AirtestError("set clipboard failed: %s" % ret)
 
     def change_lang(self, lang):
         """

--- a/airtest/core/android/yosemite_ext.py
+++ b/airtest/core/android/yosemite_ext.py
@@ -1,0 +1,60 @@
+from .constant import YOSEMITE_APK, YOSEMITE_PACKAGE
+from airtest.core.android.yosemite import Yosemite
+from airtest.core.error import AirtestError
+from airtest.utils.logger import get_logger
+LOGGING = get_logger(__name__)
+
+
+class YosemiteExt(Yosemite):
+
+    def __init__(self, adb):
+        super(YosemiteExt, self).__init__(adb)
+        self._path = ""
+
+    @property
+    def path(self):
+        if not self._path:
+            self._path = self.adb.path_app(YOSEMITE_PACKAGE)
+        return self._path
+
+    def device_op(self, op_name, op_args=""):
+        """
+        Perform device operations
+
+        Args:
+            op_name: operation name
+            op_args: operation args
+
+        Returns:
+            None
+
+        """
+        return self.adb.shell(f"app_process -Djava.class.path={self.path} / com.netease.nie.yosemite.control.Control --DEVICE_OP {op_name} {op_args}")
+
+    def get_clipboard(self):
+        """
+        Get clipboard content
+
+        Returns:
+            clipboard content
+
+        """
+        text = self.device_op("clipboard_get")
+        if text:
+            return text.strip()
+        return ""
+
+    def set_clipboard(self, text):
+        """
+        Set clipboard content
+
+        Args:
+            text: text to be set
+
+        Returns:
+            None
+
+        """
+        ret = self.device_op("clipboard", f"--TEXT {text}")
+        if ret and "Exception" in ret:
+            raise AirtestError("set clipboard failed: %s" % ret)

--- a/airtest/core/api.py
+++ b/airtest/core/api.py
@@ -46,6 +46,7 @@ def init_device(platform="Android", uuid=None, **kwargs):
     return dev
 
 
+@logwrap
 def connect_device(uri):
     """
     Initialize device with uri, and set as current device.
@@ -138,12 +139,12 @@ def auto_setup(basedir=None, devices=None, logdir=None, project_root=None, compr
             basedir = os.path.dirname(basedir)
         if basedir not in G.BASEDIR:
             G.BASEDIR.append(basedir)
-    if devices:
-        for dev in devices:
-            connect_device(dev)
     if logdir:
         logdir = script_log_dir(basedir, logdir)
         set_logdir(logdir)
+    if devices:
+        for dev in devices:
+            connect_device(dev)
     if project_root:
         ST.PROJECT_ROOT = project_root
     if compress:

--- a/airtest/core/api.py
+++ b/airtest/core/api.py
@@ -232,11 +232,11 @@ def install(filepath, **kwargs):
     :return: None
     :platforms: Android, iOS
     :Example:
-        >>> install(r"D:\\demo\\test.apk")  # install Android apk
+        >>> install(r"D:\demo\test.apk")  # install Android apk
         >>> # adb install -r -t D:\\demo\\test.apk
-        >>> install(r"D:\\demo\\test.apk", install_options=["-r", "-t"])
+        >>> install(r"D:\demo\test.apk", install_options=["-r", "-t"])
 
-        >>> install(r"D:\\demo\\test.ipa") # install iOS ipa
+        >>> install(r"D:\demo\test.ipa") # install iOS ipa
         >>> install("http://www.example.com/test.ipa") # install iOS ipa from url
 
     """
@@ -672,7 +672,11 @@ def get_clipboard(*args, **kwargs):
     :platforms: iOS
     :Example:
 
-        >>> text = get_clipboard(wda_bundle_id="com.WebDriverAgentRunner.xctrunner")  # iOS
+        >>> text = get_clipboard()  # local iOS
+        >>> print(text)
+
+        >>> # When the iOS device is a remote device, or more than one wda is installed on the device, you need to specify the wda_bundle_id
+        >>> text = get_clipboard(wda_bundle_id="com.WebDriverAgentRunner.xctrunner")
         >>> print(text)
 
     """
@@ -689,7 +693,10 @@ def set_clipboard(content, *args, **kwargs):
     :platforms: iOS
     :Example:
 
-        >>> set_clipboard("content", wda_bundle_id="com.WebDriverAgentRunner.xctrunner")  # iOS
+        >>> set_clipboard("content")  # local iOS
+
+        >>> # When the iOS device is a remote device, or more than one wda is installed on the device, you need to specify the wda_bundle_id
+        >>> set_clipboard("content", wda_bundle_id="com.WebDriverAgentRunner.xctrunner")
 
     """
     G.DEVICE.set_clipboard(content, *args, **kwargs)

--- a/airtest/core/api.py
+++ b/airtest/core/api.py
@@ -664,10 +664,10 @@ def get_clipboard(*args, **kwargs):
     Get the content from the clipboard.
 
     :return: str
-    :platforms: iOS
+    :platforms: Android, iOS
     :Example:
 
-        >>> text = get_clipboard()  # local iOS
+        >>> text = get_clipboard()  # Android or local iOS
         >>> print(text)
 
         >>> # When the iOS device is a remote device, or more than one wda is installed on the device, you need to specify the wda_bundle_id
@@ -685,10 +685,11 @@ def set_clipboard(content, *args, **kwargs):
 
     :param content: str
     :return: None
-    :platforms: iOS
+    :platforms: Android, iOS
     :Example:
 
-        >>> set_clipboard("content")  # local iOS
+        >>> set_clipboard("content")  # Android or local iOS
+        >>> print(get_clipboard())
 
         >>> # When the iOS device is a remote device, or more than one wda is installed on the device, you need to specify the wda_bundle_id
         >>> set_clipboard("content", wda_bundle_id="com.WebDriverAgentRunner.xctrunner")

--- a/airtest/core/api.py
+++ b/airtest/core/api.py
@@ -697,6 +697,23 @@ def set_clipboard(content, *args, **kwargs):
     """
     G.DEVICE.set_clipboard(content, *args, **kwargs)
 
+
+@logwrap
+def paste(*args, **kwargs):
+    """
+    Paste the content from the clipboard.
+
+    :platforms: Android, iOS
+    :return: None
+    :Example:
+
+        >>> set_clipboard("content")
+        >>> paste()  # will paste "content" to the device
+
+    """
+    G.DEVICE.paste(*args, **kwargs)
+
+
 """
 Assertions: see airtest/core/assertions.py
 """

--- a/airtest/core/api.py
+++ b/airtest/core/api.py
@@ -5,12 +5,11 @@ This module contains the Airtest Core APIs.
 import os
 import time
 
-from six.moves.urllib.parse import parse_qsl, urlparse
-
 from airtest.core.cv import Template, loop_find, try_log_screen
 from airtest.core.error import TargetNotFoundError
 from airtest.core.settings import Settings as ST
 from airtest.utils.compat import script_log_dir
+from airtest.utils.snippet import parse_device_uri
 from airtest.core.helper import (G, delay_after_operation, import_device_cls,
                                  logwrap, set_logdir, using, log)
 # Assertions
@@ -60,6 +59,7 @@ def connect_device(uri):
         >>> connect_device("Android:///SJE5T17B17?cap_method=javacap&touch_method=adb")
         >>> # remote device using custom params Android://adbhost:adbport/serialno
         >>> connect_device("Android://127.0.0.1:5037/10.254.60.1:5555")
+        >>> connect_device("Android://127.0.0.1:5037/10.234.60.1:5555?name=serialnumber")  # add serialno to params
         >>> connect_device("Windows:///")  # connect to the desktop
         >>> connect_device("Windows:///123456")  # Connect to the window with handle 123456
         >>> connect_device("windows:///?title_re='.*explorer.*'")  # Connect to the window that name include "explorer"
@@ -70,13 +70,7 @@ def connect_device(uri):
         >>> connect_device("iOS:///http://localhost:8100/?mjpeg_port=9100&&uuid=00008020-001270842E88002E")  # udid/uuid/serialno are all ok
 
     """
-    d = urlparse(uri)
-    platform = d.scheme
-    host = d.netloc
-    uuid = d.path.lstrip("/")
-    params = dict(parse_qsl(d.query))
-    if host:
-        params["host"] = host.split(":")
+    platform, uuid, params = parse_device_uri(uri)
     dev = init_device(platform, uuid, **params)
     return dev
 

--- a/airtest/core/device.py
+++ b/airtest/core/device.py
@@ -18,6 +18,9 @@ class Device(with_metaclass(MetaDevice, object)):
     def __init__(self):
         super(Device, self).__init__()
 
+    def to_json(self):
+        return f"<{self.__class__.__name__} {self.uuid}>"
+
     @property
     def uuid(self):
         self._raise_not_implemented_error()

--- a/airtest/core/device.py
+++ b/airtest/core/device.py
@@ -19,7 +19,11 @@ class Device(with_metaclass(MetaDevice, object)):
         super(Device, self).__init__()
 
     def to_json(self):
-        return f"<{self.__class__.__name__} {self.uuid}>"
+        try:
+            uuid = repr(self.uuid)
+        except:
+            uuid = None
+        return f"<{self.__class__.__name__} {uuid}>"
 
     @property
     def uuid(self):

--- a/airtest/core/helper.py
+++ b/airtest/core/helper.py
@@ -197,7 +197,8 @@ def using(path):
                 baz.air
                 main.py
 
-        If we want to reference foo/bar.air and baz.air in main.py, we can write::
+        If we want to reference `foo/bar.air` and `baz.air` in main.py, we can set the project root path to ``ST.PROJECT_ROOT``, \
+        or make sure the project root path is the `current working directory`. We can write::
 
             # main.py
             from airtest.core.api import *
@@ -205,7 +206,7 @@ def using(path):
             using("foo/bar.air")
             using("baz.air")
 
-        If we want to reference baz.air in foo/bar.air, we can write::
+        If we want to reference `baz.air` in `foo/bar.air`, we can write::
 
             # foo/bar.air
             from airtest.core.api import *

--- a/airtest/core/ios/ios.py
+++ b/airtest/core/ios/ios.py
@@ -66,23 +66,20 @@ def decorator_pairing_dialog(func):
         try:
             return func(*args, **kwargs)
         except MuxError:
-            LOGGING.error("Device is not yet paired. Triggered the trust dialogue. Please accept and try again." + \
-                          "(iTunes is required on Windows.) " if sys.platform.startswith("win") else "")
+            LOGGING.error("Device is not yet paired. Triggered the trust dialogue. Please accept and try again." + "(iTunes is required on Windows.) " if sys.platform.startswith("win") else "")
             raise
     return wrapper
 
 
 def add_decorator_to_methods(decorator):
     """
-    This function takes a decorator as input and returns a decorator wrapper function. \
-    The decorator wrapper function takes a class as input and decorates all the methods of the class by applying the input decorator to each method.
+    This function takes a decorator as input and returns a decorator wrapper function. The decorator wrapper function takes a class as input and decorates all the methods of the class by applying the input decorator to each method.
 
     Parameters:
         - decorator: A decorator function that will be applied to the methods of the input class.
 
     Returns:
-        - decorator_wrapper: A function that takes a class as input and decorates all the methods of the class \
-        by applying the input decorator to each method.
+        - decorator_wrapper: A function that takes a class as input and decorates all the methods of the class by applying the input decorator to each method.
     """
     def decorator_wrapper(cls):
         # 获取要装饰的类的所有方法
@@ -103,7 +100,13 @@ class TIDevice:
 
     @staticmethod
     def devices():
-        # Get all available devices connect by usb, reutrn list of udid.
+        """
+        Get all available devices connected by USB, return a list of UDIDs.
+
+        Returns:
+            list: A list of UDIDs. 
+            e.g. ['539c5fffb18f2be0bf7f771d68f7c327fb68d2d9']
+        """
         return Usbmux().device_udid_list()
     
     @staticmethod
@@ -214,6 +217,21 @@ class TIDevice:
 
     @staticmethod
     def ps(udid):
+        """
+        Retrieves the process list of the specified device.
+
+        Parameters:
+            udid (str): The unique device identifier.
+
+        Returns:
+            list: A list of dictionaries containing information about each process. Each dictionary contains the following keys:
+                - pid (int): The process ID.
+                - name (str): The name of the process.
+                - bundle_id (str): The bundle identifier of the process.
+                - display_name (str): The display name of the process.
+            e.g. [{'pid': 1, 'name': 'MobileSafari', 'bundle_id': 'com.apple.mobilesafari', 'display_name': 'Safari'}, ...]
+
+        """
         with BaseDevice(udid, Usbmux()).connect_instruments() as ts:
             app_infos = list(BaseDevice(udid, Usbmux()).installation.iter_installed(app_type=None))
             ps = list(ts.app_process_list(app_infos))
@@ -847,7 +865,7 @@ class IOS(Device):
         """
         if not self.is_local_device:
             raise RuntimeError("Can noly use this method in local device now, not remote device.")
-        return TIDevice.list_app(self.udid, type=type)
+        return TIDevice.list_app(self.udid, app_type=type)
 
     def app_state(self, bundle_id):
         """ Get app state and ruturn.

--- a/airtest/core/ios/ios.py
+++ b/airtest/core/ios/ios.py
@@ -279,7 +279,7 @@ class IOS(Device):
         - ``iproxy $port 8100 $udid``
     """
 
-    def __init__(self, addr=DEFAULT_ADDR, cap_method=CAP_METHOD.MJPEG, mjpeg_port=None, udid=None, uuid=None, serialno=None, wda_bundle_id=None):
+    def __init__(self, addr=DEFAULT_ADDR, cap_method=CAP_METHOD.MJPEG, mjpeg_port=None, udid=None, name=None, serialno=None, wda_bundle_id=None):
         super(IOS, self).__init__()
 
         # If none or empty, use default addr.
@@ -343,7 +343,7 @@ class IOS(Device):
         self.recorder = None
 
         # Since uuid and udid are very similar, both names are allowed.
-        self._udid = udid or uuid or serialno
+        self._udid = udid or name or serialno
 
     def _get_default_device(self):
         """Get local default device when no udid.
@@ -506,7 +506,7 @@ class IOS(Device):
     def orientation(self):
         """
         Returns:
-            Device oritantation status in LANDSACPE POR.
+            Device orientation status in LANDSACPE POR.
         """
         if not self._current_orientation:
             self._current_orientation = self.get_orientation()
@@ -1141,7 +1141,7 @@ class IOS(Device):
         return False
 
     def disconnect(self):
-        """Discconect mjpeg and rotation_watcher.
+        """Disconnected mjpeg and rotation_watcher.
         """
         if self.cap_method == CAP_METHOD.MJPEG:
             self.mjpegcap.teardown_stream()

--- a/airtest/core/ios/ios.py
+++ b/airtest/core/ios/ios.py
@@ -971,6 +971,21 @@ class IOS(Device):
         else:
             LOGGING.warning("we can't switch back to the app before, becasue can't get bundle id.")
 
+    def paste(self, wda_bundle_id=None, *args, **kwargs):
+        """
+        Paste the current clipboard content on the device.
+
+        Args:
+            wda_bundle_id (str, optional): The bundle ID of the WDA app. Defaults to None.
+
+        Raises:
+            RuntimeError: If the device is remote and the wda_bundle_id parameter is not provided.
+
+        Returns:
+            None
+        """
+        self.text(self.get_clipboard(wda_bundle_id=wda_bundle_id))
+
     def get_ip_address(self):
         """Get ip address from WDA.
 

--- a/airtest/report/css/report.css
+++ b/airtest/report/css/report.css
@@ -139,7 +139,7 @@ h2.empty-report{
   cursor: context-menu;
   position: relative;
 }
-.summary .info-execute #copy_path{
+.summary .info-execute .copy-img{
   display: inline-block;
   margin-left: 10px;
   width: 20px;
@@ -147,7 +147,7 @@ h2.empty-report{
   cursor: context-menu;
   opacity: 0.6;
 }
-.summary .info-execute #copy_path:hover{
+.summary .info-execute .copy-img:hover{
   opacity: 1;
 }
 .summary .circle-img{

--- a/airtest/report/js/langpack/zh_CN.js
+++ b/airtest/report/js/langpack/zh_CN.js
@@ -72,6 +72,7 @@ Lang.prototype.pack.zh = {
 		"Total": "共",
 		"Warning: No steps": "警告：没有步骤",
 		"Connect device": "连接设备",
+		"Device:": "设备：",
 		"© 1997 - 2019 NetEase, Inc. All Rights Reserved.": "© 1997 - 2019 网易公司版权所有"
 	}
 };

--- a/airtest/report/js/langpack/zh_CN.js
+++ b/airtest/report/js/langpack/zh_CN.js
@@ -71,6 +71,7 @@ Lang.prototype.pack.zh = {
 		"Status:": "结果：",
 		"Total": "共",
 		"Warning: No steps": "警告：没有步骤",
+		"Connect device": "连接设备",
 		"© 1997 - 2019 NetEase, Inc. All Rights Reserved.": "© 1997 - 2019 网易公司版权所有"
 	}
 };

--- a/airtest/report/js/report.js
+++ b/airtest/report/js/report.js
@@ -906,8 +906,8 @@ $(function(){
   }
 
   // 复制脚本地址到粘贴版
-  $('#copy_path').click(function(){
-    copyToClipboard(this.getAttribute('path'))
+  $('.copy-img').click(function(){
+    copyToClipboard(this.getAttribute('data-value'))
   })
 
   // 从地址search部分加载设备信息等

--- a/airtest/report/log_template.html
+++ b/airtest/report/log_template.html
@@ -102,9 +102,20 @@
                     <div class="info-execute">
                       <div class="circle-img"></div>
                       <div class="info-file" title="{{info.path}}">{{info.name}}
-                        <img id="copy_path" path="{{info.path}}" title="copy file path to clipboard" src="{{static_root}}image/copy.svg" />
+                        <img id="copy_path" class="copy-img" data-value="{{info.path}}" title="copy file path to clipboard" src="{{static_root}}image/copy.svg" />
                       </div>
                     </div>
+
+                    {% if info.devices %}
+                    <div class="info-execute">
+                      <div class="circle-img"></div>
+                      {% set devices_str=info.devices.values() | join(',') %}
+                      <div class="info-file" title="{{ devices_str }}">{{info.devices.keys() | join(',') }}
+                        <img class="copy-img" title="copy file path to clipboard" src="{{static_root}}image/copy.svg" data-value="{{ devices_str }}"/>
+                      </div>
+                    </div>
+                    {% endif %}
+
                   </div>
                 </div>
               </div>

--- a/airtest/report/log_template.html
+++ b/airtest/report/log_template.html
@@ -110,7 +110,7 @@
                     <div class="info-execute">
                       <div class="circle-img"></div>
                       {% set devices_str=info.devices.values() | join(',') %}
-                      <div class="info-file" title="{{ devices_str }}">{{info.devices.keys() | join(',') }}
+                      <div class="info-file" title="{{ devices_str }}"><span lang="en">Device: </span> {{info.devices.keys() | join(',') }}
                         <img class="copy-img" title="copy file path to clipboard" src="{{static_root}}image/copy.svg" data-value="{{ devices_str }}"/>
                       </div>
                     </div>

--- a/airtest/report/report.py
+++ b/airtest/report/report.py
@@ -13,6 +13,7 @@ import traceback
 from copy import deepcopy
 from datetime import datetime
 from markupsafe import Markup, escape
+from six.moves.urllib.parse import parse_qsl, urlparse
 try:
     from jinja2 import evalcontextfilter as pass_eval_context  # jinja2<3.1
 except:
@@ -61,6 +62,7 @@ class LogToHtml(object):
 
     def __init__(self, script_root, log_root="", static_root="", export_dir=None, script_name="", logfile=None, lang="en", plugins=None):
         self.log = []
+        self.devices = {}
         self.script_root = script_root
         self.script_name = script_name
         if not self.script_name or os.path.isfile(self.script_root):
@@ -132,6 +134,7 @@ class LogToHtml(object):
         screen = self._translate_screen(step, code)
         info = self._translate_info(step)
         assertion = self._translate_assertion(step)
+        self._translate_device(step)
 
         translated = {
             "title": title,
@@ -209,6 +212,16 @@ class LogToHtml(object):
         if display_pos:
             screen["pos"].append(display_pos)
         return screen
+
+    def _translate_device(self, step):
+        if step["tag"] == "function" and step["data"]["name"] == "connect_device":
+            uri = step["data"]["call_args"]["uri"]
+            d = urlparse(uri)
+            uuid = d.path.lstrip("/")
+            if uuid not in self.devices:
+                self.devices[uuid] = uri
+            return uuid
+        return None
 
     @classmethod
     def get_thumbnail(cls, path):
@@ -310,6 +323,7 @@ class LogToHtml(object):
             "sleep": lambda: u"Wait for %s seconds" % args.get('secs'),
             "assert_exists": u"Assert target image exists",
             "assert_not_exists": u"Assert target image does not exists",
+            "connect_device": lambda : u"Connect device: %s" % args.get("uri"),
         }
 
         # todo: 最好用js里的多语言实现
@@ -324,6 +338,7 @@ class LogToHtml(object):
             "sleep": lambda: u"等待%s秒" % args.get('secs'),
             "assert_exists": u"断言目标图片存在",
             "assert_not_exists": u"断言目标图片不存在",
+            "connect_device": lambda : u"连接设备： %s" % args.get("uri"),
         }
 
         if self.lang == "zh":
@@ -348,6 +363,7 @@ class LogToHtml(object):
             "snapshot": u"Snapshot",
             "assert_equal": u"Assert equal",
             "assert_not_equal": u"Assert not equal",
+            "connect_device": u"Connect device",
         }
 
         return title.get(name, name)
@@ -462,6 +478,7 @@ class LogToHtml(object):
 
         script_path = os.path.join(self.script_root, self.script_name)
         info = json.loads(get_script_info(script_path))
+        info['devices'] = self.devices
 
         if record_list:
             records = [os.path.join(DEFAULT_LOG_DIR, f) if self.export_dir

--- a/airtest/report/report.py
+++ b/airtest/report/report.py
@@ -25,6 +25,7 @@ from airtest.aircv.utils import compress_image
 from airtest.utils.compat import decode_path, script_dir_name
 from airtest.cli.info import get_script_info
 from airtest.utils.logger import get_logger
+from airtest.utils.snippet import parse_device_uri
 from six import PY3
 
 LOGGING = get_logger(__name__)
@@ -216,8 +217,9 @@ class LogToHtml(object):
     def _translate_device(self, step):
         if step["tag"] == "function" and step["data"]["name"] == "connect_device":
             uri = step["data"]["call_args"]["uri"]
-            d = urlparse(uri)
-            uuid = d.path.lstrip("/")
+            platform, uuid, params = parse_device_uri(uri)
+            if "name" in params:
+                uuid = params["name"]
             if uuid not in self.devices:
                 self.devices[uuid] = uri
             return uuid

--- a/airtest/utils/logwraper.py
+++ b/airtest/utils/logwraper.py
@@ -36,7 +36,10 @@ class AirtestLogger(object):
     @staticmethod
     def _dumper(obj):
         if hasattr(obj, "to_json"):
-            return obj.to_json()
+            try:
+                return obj.to_json()
+            except:
+                repr(obj)
         try:
             d = copy(obj.__dict__)
             try:
@@ -75,7 +78,11 @@ class AirtestLogger(object):
         while self.running_stack:
             # 先取最后一个，记了log之后再pop，避免depth错误
             log_stacked = self.running_stack[-1]
-            self.log("function", log_stacked)
+            try:
+                self.log("function", log_stacked)
+            except Exception as e:
+                LOGGING.error("log_stacked error: %s" % e)
+                LOGGING.error(traceback.format_exc())
             self.running_stack.pop()
 
 

--- a/airtest/utils/snippet.py
+++ b/airtest/utils/snippet.py
@@ -6,6 +6,7 @@ import threading
 from functools import wraps
 from six import string_types
 from six.moves import queue
+from six.moves.urllib.parse import parse_qsl, urlparse
 
 
 def split_cmd(cmds):
@@ -151,3 +152,23 @@ def make_file_executable(file_path):
             os.chmod(file_path, mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
         return True
     return False
+
+
+def parse_device_uri(uri):
+    """
+    Parse device uri to get platform, host, uuid and other params
+
+    Args:
+        uri: e.g. Android:///SJE5T17B17?cap_method=javacap&touch_method=adb
+
+    Returns:
+
+    """
+    d = urlparse(uri)
+    platform = d.scheme
+    host = d.netloc
+    uuid = d.path.lstrip("/")
+    params = dict(parse_qsl(d.query))
+    if host:
+        params["host"] = host.split(":")
+    return platform, uuid, params

--- a/airtest/utils/snippet.py
+++ b/airtest/utils/snippet.py
@@ -1,5 +1,6 @@
 # _*_ coding:UTF-8 _*_
 import os
+import re
 import sys
 import stat
 import threading
@@ -172,3 +173,16 @@ def parse_device_uri(uri):
     if host:
         params["host"] = host.split(":")
     return platform, uuid, params
+
+
+def escape_special_char(string):
+    """
+    Escape special characters in a string.
+
+    Args:
+        string (str): The input string, e.g. 'testing !@#$%^&*()_+'
+
+    Returns:
+        str: The string with special characters escaped.  e.g. 'testing \!\@\#\$\%\^\&\*\(\)_\+'
+    """
+    return re.sub(r'([!@#\$%\^&\*\(\)_\+\\|;:"\'<>\?\{\}\[\]#\~\^ ])', r'\\\1', string)

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ pywinauto==0.6.3
 filelock
 ffmpeg-python
 tidevice
+psutil

--- a/tests/test_android.py
+++ b/tests/test_android.py
@@ -140,6 +140,19 @@ class TestAndroid(unittest.TestCase):
         self.android.ime_method = IME_METHOD.YOSEMITEIME
         self.android.text(u'你好')
 
+    def test_clipboard(self):
+        text1 = "test clipboard"
+        self.android.set_clipboard(text1)
+        self.assertEqual(self.android.get_clipboard(), text1)
+
+        self.android.paste()
+
+        # test escape special char
+        text2 = "test clipboard with $pecial char #@!#%$#^&*()'"
+        self.android.set_clipboard(text2)
+        self.assertEqual(self.android.get_clipboard(), text2)
+        self.android.paste()
+
     def test_touch(self):
         for i in (TOUCH_METHOD.ADBTOUCH, TOUCH_METHOD.MINITOUCH, TOUCH_METHOD.MAXTOUCH):
             self.android.touch_method = i

--- a/tests/test_tidevice.py
+++ b/tests/test_tidevice.py
@@ -25,12 +25,15 @@ class TIDeviceTests(unittest.TestCase):
         if len(app_list) > 0:
             self.assertEqual(len(app_list[0]), 3)
 
-    def test_list_app_system(self):
+    def test_list_app_type(self):
         app_list = TIDevice.list_app(self.udid, app_type='system')
         print(app_list)
         self.assertIsInstance(app_list, list)
         if len(app_list) > 0:
             self.assertEqual(len(app_list[0]), 3)
+
+        app_list_all = TIDevice.list_app(self.udid, app_type='all')
+        self.assertGreater(len(app_list_all), len(app_list))
 
     def test_list_wda(self):
         wda_list = TIDevice.list_wda(self.udid)
@@ -47,6 +50,11 @@ class TIDeviceTests(unittest.TestCase):
 
     def test_stop_app(self):
         TIDevice.stop_app(self.udid, "com.apple.mobilesafari")
+
+    def test_ps(self):
+        ps = TIDevice.ps(self.udid)
+        print(ps)
+        self.assertIsInstance(ps, list)
 
     def test_ps_wda(self):
         ps_wda = TIDevice.ps_wda(self.udid)

--- a/tests/test_yosemite.py
+++ b/tests/test_yosemite.py
@@ -52,6 +52,10 @@ class TestIme(unittest.TestCase):
         self.ime.text("nimei")
         self.ime.text("你妹")
 
+    def test_escape_text(self):
+        self.ime.text("$call org/org->create_org($id,'test123')")
+        self.ime.text("#@$%^&&*)_+!")
+
     def test_code(self):
         self.ime.text("test code")
         self.ime.code("2")


### PR DESCRIPTION
1. 报告中现在将会显示connect_device接口连接的设备
2. ios和android设备在连接时，支持传入name参数，用于指定它的udid(ios)或serial number(android)
例如： `ios:///http://10.240.145.171:20092?name=83282c400efc9122e3bcba60c803cf318a6b3822`
安卓远程设备： `android://127.0.0.1:5037/10.227.71.86:20029?name=serialno`
3. adb现在将会优先使用当前的adb进程，或者是系统变量设置了ANDROID_HOME中的adb，如果都找不到，才会使用airtest里的adb。
同时也支持直接指定`adb_path`，例如：
```
from airtest.core.android.android import Android, ADB

adb = ADB(adb_path=r"D:\adb\adb.exe")

# 或者可以初始化一个指定了adb_path的Android设备对象
dev = Android(serialno="5TSSMVBYUSEQNRY5", adb_path=r"D:\test\adb41\adb.exe")
```

5. 剪贴板的相关接口增加了安卓的支持，增加了粘贴接口（`paste`，效果等同于执行 `text(get_clipboard())`）

```
text = "test_clipboard"
set_clipboard(text)

get_text = get_clipboard()
print(get_text)  # -> test_clipboard

paste()  # => text(get_clipboard())
```

bug修复：
修复了一些小问题
如果遇到了手机画面只有一半的情况，重新连接画面即可恢复。

* * *

1. The report will now display the devices connected to the connect_device interface.
2. When connecting ios and android devices, the name parameter can be passed in to specify its udid (ios) or serial number (android)
For example: `ios:///http://10.240.145.171:20092?name=83282c400efc9122e3bcba60c803cf318a6b3822`
Android remote device: `android://127.0.0.1:5037/10.227.71.86:20029?name=serialno`
3. adb will now give priority to using the current adb process, or the system variable is set to adb in ANDROID_HOME. If neither is found, adb in airtest will be used.
It also supports directly specifying `adb_path`, for example:
```
from airtest.core.android.android import Android, ADB

adb = ADB(adb_path=r"D:\adb\adb.exe")

# Or specify adb_path when initializing the Android object
dev = Android(serialno="5TSSMVBYUSEQNRY5", adb_path=r"D:\test\adb41\adb.exe")
```
5. The relevant interfaces of the clipboard have been added with Android support and a paste interface (`paste`, the effect is equivalent to executing `text(get_clipboard())`)

```
text = "test_clipboard"
set_clipboard(text)

get_text = get_clipboard()
print(get_text) # -> test_clipboard

paste() # => text(get_clipboard())
```

bug fixes:
Fixed some minor issues
If you encounter a situation where the screen on your phone is only half full, you can restore the screen by reconnecting.