### PR TITLE
修复WDA bundleID获取异常，同tidevice一致

### DIFF
--- a/airtest/core/ios/ios.py
+++ b/airtest/core/ios/ios.py
@@ -151,7 +151,7 @@ class TIDevice:
         wda_list = []
         for app in app_list:
             bundle_id, display_name, _ = app
-            if ".xctrunner" in bundle_id or display_name == "WebDriverAgentRunner-Runner":
+            if (bundle_id.startswith('com.') and bundle_id.endswith(".xctrunner")) or display_name == "WebDriverAgentRunner-Runner":
                 wda_list.append(bundle_id)
         return wda_list
     


### PR DESCRIPTION
当设备装有字节的fastboot时，获取wda bundleID不正确，原因是bundleID的判断有问题。
![image](https://github.com/AirtestProject/Airtest/assets/50130180/d6cd4101-636d-4ae1-a28d-9a32c077acf6)

将bundleID判断同tidevice一致后，获取结果正确
![image](https://github.com/AirtestProject/Airtest/assets/50130180/6aa6f5fa-5f05-48ac-90f0-4c54c3a18c2a)


另一种建议
https://github.com/AirtestProject/Airtest/blob/master/airtest/core/ios/ios.py#L322C27-L322C27
如果wda_bundle_id没有其他用途的话，可以直接透传，由tidevice决定需要启动的wda。


tidevice相关
https://github.com/alibaba/taobao-iphone-device/blob/main/tidevice/_device.py#L964
tidevice识别wda的bundleID标识为com.*.xctrunner

