### PR TITLE
V1.3.3

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -17,6 +17,6 @@ sphinx:
 
 # We recommend specifying your dependencies to enable reproducible builds:
 # https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
-# python:
-#   install:
-#   - requirements: docs/requirements.txt
+python:
+  install:
+  - requirements: docs/requirements.txt

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,22 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.6"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+
+# We recommend specifying your dependencies to enable reproducible builds:
+# https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+# python:
+#   install:
+#   - requirements: docs/requirements.txt

--- a/airtest/core/android/adb.py
+++ b/airtest/core/android/adb.py
@@ -71,7 +71,7 @@ class ADB(object):
 
         # Check if adb process is already running
         for process in psutil.process_iter(['name', 'exe']):
-            if process.info['name'] == ADB_NAME:
+            if process.info['name'] == ADB_NAME and process.info['exe'] and os.path.exists(process.info['exe']):
                 return process.info['exe']
 
         # Check if ANDROID_HOME environment variable exists

--- a/airtest/core/android/adb.py
+++ b/airtest/core/android/adb.py
@@ -70,9 +70,13 @@ class ADB(object):
             ADB_NAME = "adb"
 
         # Check if adb process is already running
-        for process in psutil.process_iter(['name', 'exe']):
-            if process.info['name'] == ADB_NAME and process.info['exe'] and os.path.exists(process.info['exe']):
-                return process.info['exe']
+        try:
+            for process in psutil.process_iter(['name', 'exe']):
+                if process.info['name'] == ADB_NAME and process.info['exe'] and os.path.exists(process.info['exe']):
+                    return process.info['exe']
+        except:
+            # maybe OSError
+            pass
 
         # Check if ANDROID_HOME environment variable exists
         android_home = os.environ.get('ANDROID_HOME')

--- a/airtest/core/android/android.py
+++ b/airtest/core/android/android.py
@@ -595,17 +595,19 @@ class Android(Device):
             >>> dev.touch((0.5, 0.5))  # relative coordinates
 
         Returns:
-            None
+            (x, y)  # The coordinate position of the actual click
 
         """
         pos = get_absolute_coordinate(pos, self)
         self.touch_proxy.touch(pos, duration)
+        return pos
 
     def double_click(self, pos):
         pos = get_absolute_coordinate(pos, self)
         self.touch(pos)
         time.sleep(0.05)
         self.touch(pos)
+        return pos
 
     def swipe(self, p1, p2, duration=0.5, steps=5, fingers=1):
         """
@@ -624,12 +626,13 @@ class Android(Device):
             >>> dev.swipe((0.1, 0.1), (0.2, 0.2))  # relative coordinates
 
         Returns:
-            None
+            (pos1, pos2)
 
         """
         p1 = get_absolute_coordinate(p1, self)
         p2 = get_absolute_coordinate(p2, self)
         self.touch_proxy.swipe(p1, p2, duration=duration, steps=steps, fingers=fingers)
+        return p1, p2
 
     def pinch(self, center=None, percent=0.5, duration=0.5, steps=5, in_or_out='in'):
         """

--- a/airtest/core/android/android.py
+++ b/airtest/core/android/android.py
@@ -45,7 +45,7 @@ class Android(Device):
                  adb_path=None,
                  name=None):
         super(Android, self).__init__()
-        self.serialno = serialno or self.get_default_device()
+        self.serialno = serialno or self.get_default_device(adb_path=adb_path)
         self._uuid = name or self.serialno
         self._cap_method = cap_method.upper()
         self._touch_method = touch_method.upper()

--- a/airtest/core/android/android.py
+++ b/airtest/core/android/android.py
@@ -1004,6 +1004,13 @@ class Android(Device):
         Returns:
             clipboard content
 
+        Examples:
+            >>> dev = Android()
+            >>> dev.set_clipboard("hello world")
+            >>> dev.get_clipboard()
+            'hello world'
+            >>> dev.paste()  # paste the clipboard content
+
         """
         return self.yosemite_ext.get_clipboard()
 
@@ -1019,14 +1026,6 @@ class Android(Device):
 
         """
         self.yosemite_ext.set_clipboard(text)
-
-    def paste(self):
-        """
-        Paste the clipboard content
-        Returns:
-
-        """
-        self.text(self.get_clipboard())
 
     def _register_rotation_watcher(self):
         """

--- a/airtest/core/android/android.py
+++ b/airtest/core/android/android.py
@@ -589,6 +589,11 @@ class Android(Device):
             pos: coordinates (x, y)
             duration: how long to touch the screen
 
+        Examples:
+            >>> dev = Android()  # or dev = device()
+            >>> dev.touch((100, 100))  # absolute coordinates
+            >>> dev.touch((0.5, 0.5))  # relative coordinates
+
         Returns:
             None
 
@@ -612,6 +617,11 @@ class Android(Device):
             duration: how long to swipe the screen, default 0.5
             steps: how big is the swipe step, default 5
             fingers: the number of fingers. 1 or 2.
+
+        Examples:
+            >>> dev = Android()  # or dev = device()
+            >>> dev.swipe((100, 100), (200, 200))  # absolute coordinates
+            >>> dev.swipe((0.1, 0.1), (0.2, 0.2))  # relative coordinates
 
         Returns:
             None

--- a/airtest/core/android/android.py
+++ b/airtest/core/android/android.py
@@ -27,6 +27,7 @@ from airtest.core.android.touch_methods.maxtouch import Maxtouch  # noqa
 
 from airtest.core.settings import Settings as ST
 from airtest.aircv.screen_recorder import ScreenRecorder, resize_by_max, get_max_size
+from airtest.utils.snippet import get_absolute_coordinate
 from airtest.utils.logger import get_logger
 
 LOGGING = get_logger(__name__)
@@ -99,6 +100,39 @@ class Android(Device):
                                                   input_event=self.input_event)
         return self._touch_proxy
 
+    @touch_proxy.setter
+    def touch_proxy(self, touch_method):
+        """
+        Specify a touch method, if the method fails to initialize, try to use other methods instead
+
+        指定一个触摸方案，如果该方法初始化失败，则尝试使用其他方法代替
+
+        Args:
+            touch_method: "MINITOUCH" or Minitouch() object
+
+        Returns:
+            TouchProxy object
+
+        Raises:
+            TouchMethodNotSupportedError when the connection fails
+
+        Examples:
+            >>> dev = Android()
+            >>> dev.touch_proxy = "MINITOUCH"
+
+            >>> from airtest.core.android.touch_methods.minitouch import Minitouch
+            >>> minitouch = Minitouch(dev.adb)
+            >>> dev.touch_proxy = minitouch
+
+        """
+        if self._screen_proxy:
+            self._screen_proxy.teardown()
+        self._touch_proxy = TouchProxy.auto_setup(self.adb,
+                                                  default_method=touch_method,
+                                                  ori_transformer=self._touch_point_by_orientation,
+                                                  size_info=self.display_info,
+                                                  input_event=self.input_event)
+
     @property
     def touch_method(self):
         """
@@ -115,6 +149,29 @@ class Android(Device):
 
         """
         return self.touch_proxy.method_name
+
+    @touch_method.setter
+    def touch_method(self, name):
+        """
+        Specify the touch method for the device, but this is not recommended
+        为设备指定触摸方案，但不建议这样做
+
+        Just to be compatible with some old codes
+        仅为了兼容一些旧的代码
+
+        Args:
+            name: "MINITOUCH" or Minitouch() object
+
+        Returns:
+            None
+
+        Examples:
+            >>> dev = Android()
+            >>> dev.touch_method = "MINITOUCH"
+
+        """
+        warnings.warn("No need to manually specify touch_method, airtest will automatically specify a suitable touch method, when airtest>=1.1.2")
+        self.touch_proxy = name
 
     @property
     def cap_method(self):
@@ -536,9 +593,11 @@ class Android(Device):
             None
 
         """
+        pos = get_absolute_coordinate(pos, self)
         self.touch_proxy.touch(pos, duration)
 
     def double_click(self, pos):
+        pos = get_absolute_coordinate(pos, self)
         self.touch(pos)
         time.sleep(0.05)
         self.touch(pos)
@@ -558,6 +617,8 @@ class Android(Device):
             None
 
         """
+        p1 = get_absolute_coordinate(p1, self)
+        p2 = get_absolute_coordinate(p2, self)
         self.touch_proxy.swipe(p1, p2, duration=duration, steps=steps, fingers=fingers)
 
     def pinch(self, center=None, percent=0.5, duration=0.5, steps=5, in_or_out='in'):
@@ -593,6 +654,7 @@ class Android(Device):
             None
 
         """
+        coordinates_list = [get_absolute_coordinate(pos, self) for pos in coordinates_list]
         self.touch_proxy.swipe_along(coordinates_list, duration=duration, steps=steps)
 
     def two_finger_swipe(self, tuple_from_xy, tuple_to_xy, duration=0.8, steps=5, offset=(0, 50)):
@@ -609,6 +671,8 @@ class Android(Device):
         Returns:
             None
         """
+        tuple_from_xy = get_absolute_coordinate(tuple_from_xy, self)
+        tuple_to_xy = get_absolute_coordinate(tuple_to_xy, self)
         self.touch_proxy.two_finger_swipe(tuple_from_xy, tuple_to_xy, duration=duration, steps=steps, offset=offset)
 
     def logcat(self, *args, **kwargs):

--- a/airtest/core/android/cap_methods/minicap.py
+++ b/airtest/core/android/cap_methods/minicap.py
@@ -398,20 +398,24 @@ class Minicap(BaseCap):
         TASK_INTERRUPTIBLE1 = "__skb_wait_for_more_packets"
         TASK_INTERRUPTIBLE2 = "futex_wait_queue_me"
 
+        shell_output = ""
         try:
             shell_output = self.adb.shell("ps -A| grep minicap")
         except:
-            pass
-        else:
-            if len(shell_output) == 0:
-                return
-            for line in shell_output.split("\r\n"):
-                if TASK_INTERRUPTIBLE1 in line or TASK_INTERRUPTIBLE2 in line:
-                    pid = line.split()[1]
-                    try:
-                        self.adb.shell("kill %s" % pid)
-                    except:
-                        pass
+            try:
+                shell_output = self.adb.shell("ps| grep minicap")
+            except:
+                pass
+
+        if len(shell_output) == 0:
+            return
+        for line in shell_output.split("\r\n"):
+            if TASK_INTERRUPTIBLE1 in line or TASK_INTERRUPTIBLE2 in line:
+                pid = line.split()[1]
+                try:
+                    self.adb.shell("kill %s" % pid)
+                except:
+                    pass
 
     def _cleanup(self):
         """

--- a/airtest/core/api.py
+++ b/airtest/core/api.py
@@ -368,7 +368,9 @@ def touch(v, times=1, **kwargs):
         try_log_screen()
         pos = v
     for _ in range(times):
-        G.DEVICE.touch(pos, **kwargs)
+        # If pos is a relative coordinate, return the converted click coordinates.
+        # iOS may all use vertical screen coordinates, so coordinates will not be returned.
+        pos = G.DEVICE.touch(pos, **kwargs) or pos
         time.sleep(0.05)
     delay_after_operation()
     return pos
@@ -393,7 +395,7 @@ def double_click(v):
     else:
         try_log_screen()
         pos = v
-    G.DEVICE.double_click(pos)
+    pos = G.DEVICE.double_click(pos) or pos
     delay_after_operation()
     return pos
 
@@ -458,7 +460,7 @@ def swipe(v1, v2=None, vector=None, **kwargs):
     else:
         raise Exception("no enough params for swipe")
 
-    G.DEVICE.swipe(pos1, pos2, **kwargs)
+    pos1, pos2 = G.DEVICE.swipe(pos1, pos2, **kwargs) or (pos1, pos2)
     delay_after_operation()
     return pos1, pos2
 

--- a/airtest/core/api.py
+++ b/airtest/core/api.py
@@ -9,7 +9,7 @@ from airtest.core.cv import Template, loop_find, try_log_screen
 from airtest.core.error import TargetNotFoundError
 from airtest.core.settings import Settings as ST
 from airtest.utils.compat import script_log_dir
-from airtest.utils.snippet import parse_device_uri, get_absolute_coordinate
+from airtest.utils.snippet import parse_device_uri
 from airtest.core.helper import (G, delay_after_operation, import_device_cls,
                                  logwrap, set_logdir, using, log)
 # Assertions
@@ -361,8 +361,8 @@ def touch(v, times=1, **kwargs):
     if isinstance(v, Template):
         pos = loop_find(v, timeout=ST.FIND_TIMEOUT)
     else:
-        pos = get_absolute_coordinate(v, G.DEVICE)
         try_log_screen()
+        pos = v
     for _ in range(times):
         G.DEVICE.touch(pos, **kwargs)
         time.sleep(0.05)
@@ -387,8 +387,8 @@ def double_click(v):
     if isinstance(v, Template):
         pos = loop_find(v, timeout=ST.FIND_TIMEOUT)
     else:
-        pos = get_absolute_coordinate(v, G.DEVICE)
         try_log_screen()
+        pos = v
     G.DEVICE.double_click(pos)
     delay_after_operation()
     return pos
@@ -435,13 +435,13 @@ def swipe(v1, v2=None, vector=None, **kwargs):
             raise
     else:
         try_log_screen()
-        pos1 = get_absolute_coordinate(v1, G.DEVICE)
+        pos1 = v1
 
     if v2:
         if isinstance(v2, Template):
             pos2 = loop_find(v2, timeout=ST.FIND_TIMEOUT_TMP)
         else:
-            pos2 = get_absolute_coordinate(v2, G.DEVICE)
+            pos2 = v2
     elif vector:
         if vector[0] <= 1 and vector[1] <= 1:
             w, h = G.DEVICE.get_current_resolution()

--- a/airtest/core/api.py
+++ b/airtest/core/api.py
@@ -9,7 +9,7 @@ from airtest.core.cv import Template, loop_find, try_log_screen
 from airtest.core.error import TargetNotFoundError
 from airtest.core.settings import Settings as ST
 from airtest.utils.compat import script_log_dir
-from airtest.utils.snippet import parse_device_uri
+from airtest.utils.snippet import parse_device_uri, get_absolute_coordinate
 from airtest.core.helper import (G, delay_after_operation, import_device_cls,
                                  logwrap, set_logdir, using, log)
 # Assertions
@@ -361,8 +361,8 @@ def touch(v, times=1, **kwargs):
     if isinstance(v, Template):
         pos = loop_find(v, timeout=ST.FIND_TIMEOUT)
     else:
+        pos = get_absolute_coordinate(v, G.DEVICE)
         try_log_screen()
-        pos = v
     for _ in range(times):
         G.DEVICE.touch(pos, **kwargs)
         time.sleep(0.05)
@@ -387,8 +387,8 @@ def double_click(v):
     if isinstance(v, Template):
         pos = loop_find(v, timeout=ST.FIND_TIMEOUT)
     else:
+        pos = get_absolute_coordinate(v, G.DEVICE)
         try_log_screen()
-        pos = v
     G.DEVICE.double_click(pos)
     delay_after_operation()
     return pos
@@ -435,13 +435,13 @@ def swipe(v1, v2=None, vector=None, **kwargs):
             raise
     else:
         try_log_screen()
-        pos1 = v1
+        pos1 = get_absolute_coordinate(v1, G.DEVICE)
 
     if v2:
         if isinstance(v2, Template):
             pos2 = loop_find(v2, timeout=ST.FIND_TIMEOUT_TMP)
         else:
-            pos2 = v2
+            pos2 = get_absolute_coordinate(v2, G.DEVICE)
     elif vector:
         if vector[0] <= 1 and vector[1] <= 1:
             w, h = G.DEVICE.get_current_resolution()

--- a/airtest/core/api.py
+++ b/airtest/core/api.py
@@ -345,6 +345,10 @@ def touch(v, times=1, **kwargs):
 
         >>> touch(Template(r"tpl1606730579419.png", target_pos=5))
 
+        Click on relative coordinates, for example, click on the center of the screen::
+
+        >>> touch((0.5, 0.5))
+
         Click 2 times::
 
         >>> touch((100, 100), times=2)
@@ -423,6 +427,10 @@ def swipe(v1, v2=None, vector=None, **kwargs):
 
         >>> # swiping lasts for 1 second, divided into 6 steps
         >>> swipe((100, 100), (200, 200), duration=1, steps=6)
+
+        Use relative coordinates to swipe, such as swiping from the center right to the left of the screen::
+
+        >>> swipe((0.7, 0.5), (0.2, 0.5))
 
     """
     if isinstance(v1, Template):

--- a/airtest/core/api.py
+++ b/airtest/core/api.py
@@ -672,7 +672,7 @@ def get_clipboard(*args, **kwargs):
     Get the content from the clipboard.
 
     :return: str
-    :platforms: Android, iOS
+    :platforms: Android, iOS, Windows
     :Example:
 
         >>> text = get_clipboard()  # Android or local iOS
@@ -693,7 +693,7 @@ def set_clipboard(content, *args, **kwargs):
 
     :param content: str
     :return: None
-    :platforms: Android, iOS
+    :platforms: Android, iOS, Windows
     :Example:
 
         >>> set_clipboard("content")  # Android or local iOS
@@ -711,7 +711,7 @@ def paste(*args, **kwargs):
     """
     Paste the content from the clipboard.
 
-    :platforms: Android, iOS
+    :platforms: Android, iOS, Windows
     :return: None
     :Example:
 

--- a/airtest/core/device.py
+++ b/airtest/core/device.py
@@ -77,6 +77,15 @@ class Device(with_metaclass(MetaDevice, object)):
     def get_ip_address(self):
         self._raise_not_implemented_error()
 
+    def set_clipboard(self, text):
+        self._raise_not_implemented_error()
+
+    def get_clipboard(self):
+        self._raise_not_implemented_error()
+
+    def paste(self):
+        self.text(self.get_clipboard())
+
     def _raise_not_implemented_error(self):
         platform = self.__class__.__name__
         raise NotImplementedError("Method not implemented on %s" % platform)

--- a/airtest/core/ios/ios.py
+++ b/airtest/core/ios/ios.py
@@ -667,7 +667,7 @@ class IOS(Device):
             pos: coordinates (x, y), can be float(percent) or int
             duration (optional): tap_hold duration
 
-        Returns: None
+        Returns: None(iOS may all use vertical screen coordinates, so coordinates will not be returned.)
 
         Examples:
             >>> touch((100, 100))

--- a/airtest/core/win/win.py
+++ b/airtest/core/win/win.py
@@ -21,6 +21,7 @@ from airtest import aircv
 from airtest.aircv.screen_recorder import ScreenRecorder, resize_by_max, get_max_size
 from airtest.core.device import Device
 from airtest.core.settings import Settings as ST
+from airtest.utils.snippet import get_absolute_coordinate
 from airtest.utils.logger import get_logger
 
 LOGGING = get_logger(__name__)
@@ -461,6 +462,7 @@ class Windows(Device):
         self.app.kill()
 
     def _action_pos(self, pos):
+        pos = get_absolute_coordinate(pos, self)
         if self.app:
             pos = self._windowpos_to_screenpos(pos)
         pos = (int(pos[0]), int(pos[1]))

--- a/airtest/core/win/win.py
+++ b/airtest/core/win/win.py
@@ -278,11 +278,13 @@ class Windows(Device):
         self.mouse.press(button=button, coords=(end_x, end_y))
         time.sleep(duration)
         self.mouse.release(button=button, coords=(end_x, end_y))
+        return (end_x, end_y)
 
     def double_click(self, pos):
         pos = self._fix_op_pos(pos)
         coords = self._action_pos(pos)
         self.mouse.double_click(coords=coords)
+        return pos
 
     def swipe(self, p1, p2, duration=0.8, steps=5, button="left"):
         """
@@ -322,6 +324,7 @@ class Windows(Device):
             self.mouse.move(coords=(to_x, to_y))
         time.sleep(interval)
         self.mouse.release(coords=(to_x, to_y), button=button)
+        return (from_x, from_y), (to_x, to_y)
 
     def mouse_move(self, pos):
         """Simulates a `mousemove` event.

--- a/airtest/core/win/win.py
+++ b/airtest/core/win/win.py
@@ -234,6 +234,12 @@ class Windows(Device):
             pos: coordinates where to click
             **kwargs: optional arguments
 
+        Examples:
+            >>> from airtest.core.api import connect_device
+            >>> dev = connect_device("Windows:///")
+            >>> dev.touch((100, 100))  # absolute coordinates
+            >>> dev.touch((0.5, 0.5))  # relative coordinates
+
         Returns:
             None
 
@@ -288,14 +294,17 @@ class Windows(Device):
             steps: size of the swipe step
             button: mouse button to press, 'left', 'right' or 'middle', default is 'left'
 
+        Examples:
+            >>> from airtest.core.api import connect_device
+            >>> dev = connect_device("Windows:///")
+            >>> dev.swipe((100, 100), (200, 200), duration=0.5)
+            >>> dev.swipe((0.1, 0.1), (0.2, 0.2), duration=0.5)
+
         Returns:
             None
 
         """
         # 设置坐标时相对于整个屏幕的坐标:
-        x1, y1 = self._fix_op_pos(p1)
-        x2, y2 = self._fix_op_pos(p2)
-
         from_x, from_y = self._action_pos(p1)
         to_x, to_y = self._action_pos(p2)
 

--- a/airtest/core/win/win.py
+++ b/airtest/core/win/win.py
@@ -252,7 +252,8 @@ class Windows(Device):
         offset = kwargs.get("offset", 0)
 
         start = self._action_pos(win32api.GetCursorPos())
-        end = self._action_pos(pos)
+        ori_end = get_absolute_coordinate(pos, self)
+        end = self._action_pos(ori_end)
         start_x, start_y = self._fix_op_pos(start)
         end_x, end_y = self._fix_op_pos(end)
 
@@ -278,13 +279,13 @@ class Windows(Device):
         self.mouse.press(button=button, coords=(end_x, end_y))
         time.sleep(duration)
         self.mouse.release(button=button, coords=(end_x, end_y))
-        return (end_x, end_y)
+        return ori_end
 
     def double_click(self, pos):
-        pos = self._fix_op_pos(pos)
-        coords = self._action_pos(pos)
+        ori_pos = get_absolute_coordinate(pos, self)
+        coords = self._fix_op_pos(self._action_pos(ori_pos))
         self.mouse.double_click(coords=coords)
-        return pos
+        return ori_pos
 
     def swipe(self, p1, p2, duration=0.8, steps=5, button="left"):
         """
@@ -308,8 +309,10 @@ class Windows(Device):
 
         """
         # 设置坐标时相对于整个屏幕的坐标:
-        from_x, from_y = self._action_pos(p1)
-        to_x, to_y = self._action_pos(p2)
+        ori_from = get_absolute_coordinate(p1, self)
+        ori_to = get_absolute_coordinate(p2, self)
+        from_x, from_y = self._fix_op_pos(self._action_pos(ori_from))
+        to_x, to_y = self._fix_op_pos(self._action_pos(ori_to))
 
         interval = float(duration) / (steps + 1)
         self.mouse.press(coords=(from_x, from_y), button=button)
@@ -324,7 +327,7 @@ class Windows(Device):
             self.mouse.move(coords=(to_x, to_y))
         time.sleep(interval)
         self.mouse.release(coords=(to_x, to_y), button=button)
-        return (from_x, from_y), (to_x, to_y)
+        return ori_from, ori_to
 
     def mouse_move(self, pos):
         """Simulates a `mousemove` event.
@@ -532,7 +535,6 @@ class Windows(Device):
         self.keyevent("^v")
 
     def _action_pos(self, pos):
-        pos = get_absolute_coordinate(pos, self)
         if self.app:
             pos = self._windowpos_to_screenpos(pos)
         pos = (int(pos[0]), int(pos[1]))

--- a/airtest/report/js/report.js
+++ b/airtest/report/js/report.js
@@ -493,14 +493,20 @@ function StepPannel(data, root){
   this.convertPos = function(domList, screen,  withSize){
     for(var i=0; i<domList.length; i++){
       var rect = JSON.parse(domList[i].getAttribute('rect'))
-      x = rect.left * this.scale
-      y = rect.top * this.scale
-      if(withSize){
-        x -= domList[i].offsetWidth/2
-        y -= domList[i].offsetHeight/2
+      // 如果是相对坐标，不需要转换
+      if (rect.left < 1 && rect.top < 1) {
+        domList[i].style.left = rect.left * 100 + '%'
+        domList[i].style.top = rect.top * 100 + '%'
+      } else {
+          x = rect.left * this.scale
+          y = rect.top * this.scale
+          if(withSize){
+            x -= domList[i].offsetWidth/2
+            y -= domList[i].offsetHeight/2
+          }
+          domList[i].style.left = this.convertPosPersentage(x, screen , 'horizontal')
+          domList[i].style.top = this.convertPosPersentage(y, screen, 'vertical')
       }
-      domList[i].style.left = this.convertPosPersentage(x, screen , 'horizontal')
-      domList[i].style.top = this.convertPosPersentage(y, screen, 'vertical')
     }
   }
 

--- a/airtest/report/js/report.js
+++ b/airtest/report/js/report.js
@@ -494,20 +494,21 @@ function StepPannel(data, root){
     for(var i=0; i<domList.length; i++){
       var rect = JSON.parse(domList[i].getAttribute('rect'))
       // 如果是相对坐标，不需要转换
-      if (rect.left < 1 && rect.top < 1) {
-        domList[i].style.left = rect.left * 100 + '%'
-        domList[i].style.top = rect.top * 100 + '%'
+      if (Math.abs(rect.left) < 1 && Math.abs(rect.top) < 1) {
+        x = rect.left * screen.width()
+        y = rect.top * screen.height()
       } else {
           x = rect.left * this.scale
           y = rect.top * this.scale
-          if(withSize){
-            x -= domList[i].offsetWidth/2
-            y -= domList[i].offsetHeight/2
-          }
-          domList[i].style.left = this.convertPosPersentage(x, screen , 'horizontal')
-          domList[i].style.top = this.convertPosPersentage(y, screen, 'vertical')
       }
+      if(withSize){
+        x -= domList[i].offsetWidth/2
+        y -= domList[i].offsetHeight/2
+      }
+      domList[i].style.left = this.convertPosPersentage(x, screen , 'horizontal')
+      domList[i].style.top = this.convertPosPersentage(y, screen, 'vertical')
     }
+
   }
 
   this.convertSize = function(domList, minWidth, minHeight) {
@@ -530,8 +531,13 @@ function StepPannel(data, root){
     var start = this.original_steps[this.currentStep].screen.pos[0]
     var vector = this.original_steps[this.currentStep].screen.vector[0]
     if(vector && start){
-      var vt_x = vector[0] * this.scale;
-      var vt_y = - vector[1] * this.scale;
+      if (Math.abs(vector[0]) < 1 && Math.abs(vector[1]) < 1) {
+        var vt_x = vector[0] * screen.width()
+        var vt_y = vector[1] * screen.height()
+      } else {
+        var vt_x = vector[0] * this.scale;
+        var vt_y = - vector[1] * this.scale;
+      }
       var vt_width = Math.sqrt(vt_x * vt_x + vt_y * vt_y)
       var rotation = 360*Math.atan2(vt_y, vt_x)/(2*Math.PI)
       var rt =  'rotate(' + -rotation + 'deg)';
@@ -543,9 +549,16 @@ function StepPannel(data, root){
         'transform-origin': '6px 15px',
       };
       dom.css(rotate_css);
+      if (Math.abs(start[0]) < 1 && Math.abs(start[1]) < 1) {
+        var top = start[1] * 100 + '%'
+        var left = start[0] * 100 + '%'
+      } else {
+        var top = this.convertPosPersentage(start[1]* this.scale, screen, 'vertical')
+        var left = this.convertPosPersentage(start[0]*this.scale, screen, 'horizontal')
+      }
       dom.css({
-        'top': this.convertPosPersentage(start[1]* this.scale, screen, 'vertical'),
-        'left': this.convertPosPersentage(start[0]*this.scale, screen, 'horizontal'),
+        'top': top,
+        'left': left,
         'width': vt_width
       });
     }

--- a/airtest/report/js/report.js
+++ b/airtest/report/js/report.js
@@ -533,7 +533,7 @@ function StepPannel(data, root){
     if(vector && start){
       if (Math.abs(vector[0]) < 1 && Math.abs(vector[1]) < 1) {
         var vt_x = vector[0] * screen.width()
-        var vt_y = vector[1] * screen.height()
+        var vt_y = - vector[1] * screen.height()
       } else {
         var vt_x = vector[0] * this.scale;
         var vt_y = - vector[1] * this.scale;

--- a/airtest/utils/snippet.py
+++ b/airtest/utils/snippet.py
@@ -190,7 +190,7 @@ def escape_special_char(string):
 
 def get_absolute_coordinate(coord, dev):
     assert isinstance(coord, (tuple, list)) and len(coord) == 2, "Coordinates must be a tuple or list of length 2"
-    assert all(isinstance(i, (int, float)) for i in coord), "Coordinates must contain only numbers (int or float)"
+    assert all(isinstance(i, (int, float)) for i in coord), f"Coordinates must contain only numbers (int or float), but got {coord}"
 
     if coord[0] <= 1 and coord[1] <= 1:
         w, h = dev.get_current_resolution()

--- a/airtest/utils/snippet.py
+++ b/airtest/utils/snippet.py
@@ -186,3 +186,13 @@ def escape_special_char(string):
         str: The string with special characters escaped.  e.g. 'testing \!\@\#\$\%\^\&\*\(\)_\+'
     """
     return re.sub(r'([!@#\$%\^&\*\(\)_\+\\|;:"\'<>\?\{\}\[\]#\~\^ ])', r'\\\1', string)
+
+
+def get_absolute_coordinate(coord, dev):
+    assert isinstance(coord, (tuple, list)) and len(coord) == 2, "Coordinates must be a tuple or list of length 2"
+    assert all(isinstance(i, (int, float)) for i in coord), "Coordinates must contain only numbers (int or float)"
+
+    if coord[0] <= 1 and coord[1] <= 1:
+        w, h = dev.get_current_resolution()
+        return (int(coord[0] * w), int(coord[1] * h))
+    return coord

--- a/airtest/utils/version.py
+++ b/airtest/utils/version.py
@@ -1,4 +1,4 @@
-__version__ = "1.3.2"
+__version__ = "1.3.3"
 
 import os
 import sys

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 sphinx
 recommonmark
-sphinx-markdown-tables
+sphinx-markdown-tables==0.0.15
 mock
 sphinx_rtd_theme

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,5 @@
+sphinx
+recommonmark
 sphinx-markdown-tables
+mock
+sphinx_rtd_theme

--- a/tests/test_android.py
+++ b/tests/test_android.py
@@ -158,6 +158,13 @@ class TestAndroid(unittest.TestCase):
             self.android.touch_method = i
             self.android.touch((100, 100))
 
+    def test_touch_percentage(self):
+        for i in (TOUCH_METHOD.ADBTOUCH, TOUCH_METHOD.MINITOUCH, TOUCH_METHOD.MAXTOUCH):
+            self.android.touch_method = i
+            self.android.touch((0.5, 0.5))
+            time.sleep(2)
+            self.android.keyevent("BACK")
+
     def test_swipe(self):
         for i in (TOUCH_METHOD.ADBTOUCH, TOUCH_METHOD.MINITOUCH, TOUCH_METHOD.MAXTOUCH):
             self.android.touch_method = i
@@ -169,6 +176,16 @@ class TestAndroid(unittest.TestCase):
         self.android.touch_method = TOUCH_METHOD.MINITOUCH
         with self.assertRaises(Exception):
             self.android.swipe((100, 100), (300, 300), fingers=3)
+
+    def test_swipe_percentage(self):
+        for i in (TOUCH_METHOD.ADBTOUCH, TOUCH_METHOD.MINITOUCH, TOUCH_METHOD.MAXTOUCH):
+            self.android.touch_method = i
+            self.android.swipe((0.6, 0.5), (0.4, 0.5))
+            self.android.swipe((0.3, 0.5), (0.6, 0.5), fingers=1)
+            self.android.swipe((0.1, 0.1), (0.3, 0.3), fingers=2)
+
+        with self.assertRaises(Exception):
+            self.android.swipe((0.1, 0.1), (0.3, 0.3), fingers=3)
 
     def test_get_top_activity(self):
         self._install_test_app()
@@ -206,6 +223,16 @@ class TestAndroid(unittest.TestCase):
         with self.assertRaises(Exception):
             self.android.swipe_along(coordinates_list)
 
+    def test_swipe_along_percentage(self):
+        coordinates_list = [(0.1, 0.3), (0.7, 0.3), (0.1, 0.7), (0.8, 0.8)]
+        for i in (TOUCH_METHOD.MINITOUCH, TOUCH_METHOD.MAXTOUCH):
+            self.android.touch_method = i
+            self.android.swipe_along(coordinates_list)
+            self.android.swipe_along(coordinates_list, duration=3, steps=10)
+        self.android.touch_method = TOUCH_METHOD.ADBTOUCH
+        with self.assertRaises(Exception):
+            self.android.swipe_along(coordinates_list)
+
     def test_two_finger_swipe(self):
         for i in (TOUCH_METHOD.MINITOUCH, TOUCH_METHOD.MAXTOUCH):
             self.android.touch_method = i
@@ -216,6 +243,17 @@ class TestAndroid(unittest.TestCase):
         self.android.touch_method = TOUCH_METHOD.ADBTOUCH
         with self.assertRaises(Exception):
             self.android.two_finger_swipe((100, 100), (200, 200))
+
+    def test_two_findger_swipe_percentage(self):
+        for i in (TOUCH_METHOD.MINITOUCH, TOUCH_METHOD.MAXTOUCH):
+            self.android.touch_method = i
+            self.android.two_finger_swipe((0.1, 0.1), (0.2, 0.2))
+            self.android.two_finger_swipe((0.1, 0.1), (0.2, 0.2), duration=3, steps=10)
+            self.android.two_finger_swipe((0.1, 0.1), (0.2, 0.2), offset=(-0.02, 0.1))
+            self.android.two_finger_swipe((0.1, 0.1), (0.2, 0.2), offset=(-0.2, 0.1))
+        self.android.touch_method = TOUCH_METHOD.ADBTOUCH
+        with self.assertRaises(Exception):
+            self.android.two_finger_swipe((0.1, 0.1), (0.2, 0.2))
 
     def test_disconnect(self):
         self.android.snapshot()

--- a/tests/test_android.py
+++ b/tests/test_android.py
@@ -141,9 +141,11 @@ class TestAndroid(unittest.TestCase):
         self.android.text(u'你好')
 
     def test_clipboard(self):
-        text1 = "test clipboard"
-        self.android.set_clipboard(text1)
-        self.assertEqual(self.android.get_clipboard(), text1)
+        for i in range(10):
+            text1 = "test clipboard" + str(i)
+            self.android.set_clipboard(text1)
+            self.assertEqual(self.android.get_clipboard(), text1)
+            self.android.paste()
 
         self.android.paste()
 

--- a/tests/test_ios.py
+++ b/tests/test_ios.py
@@ -306,9 +306,17 @@ class TestIos(unittest.TestCase):
         print(self.ios.get_clipboard())
 
     def test_set_clipboard(self):
-        print("test_set_clipboard")
-        print(self.ios.set_clipboard("test"))    
-    
+        for i in range(10):
+            text = "test_set_clipboard"+str(i)
+            self.ios.set_clipboard(text)
+            self.assertEqual(self.ios.get_clipboard(), text)
+            self.ios.paste()
+
+        text = "test clipboard with中文 $pecial char #@!#%$#^&*()'"
+        self.ios.set_clipboard(text)
+        self.assertEqual(self.ios.get_clipboard(), text)
+        self.ios.paste()
+
 
 if __name__ == '__main__':
     # unittest.main()

--- a/tests/test_win.py
+++ b/tests/test_win.py
@@ -3,7 +3,7 @@ from airtest.core.win import Windows
 import unittest
 import numpy
 import win32api
-from testconf import try_remove
+from .testconf import try_remove
 
 import time
 import os
@@ -36,7 +36,8 @@ class TestWin(unittest.TestCase):
         self.windows.text("abc")
 
     def test_touch(self):
-        self.windows.touch((11, 11))
+        self.windows.touch((100, 100))
+        # self.windows.touch((0.5, 0.5))
 
     def test_swipe(self):
         self.windows.swipe((11, 11), (100, 100))

--- a/tests/test_win.py
+++ b/tests/test_win.py
@@ -81,6 +81,17 @@ class TestWin(unittest.TestCase):
             duration = frame_num/rate
         self.assertEqual(duration >= 10, True)
 
+    def test_clipboard(self):
+        self.windows.set_clipboard("test")
+        self.assertEqual(self.windows.get_clipboard(), "test")
+
+        for i in range(10):
+            text = "test clipboard with中文 $pecial char #@!#%$#^&*()'" + str(i)
+            self.windows.set_clipboard(text)
+            self.assertEqual(self.windows.get_clipboard(), text)
+            time.sleep(0.5)
+
+
     @classmethod
     def tearDownClass(cls):
         try_remove('test_10s.mp4')

--- a/tests/test_win.py
+++ b/tests/test_win.py
@@ -37,10 +37,11 @@ class TestWin(unittest.TestCase):
 
     def test_touch(self):
         self.windows.touch((100, 100))
-        # self.windows.touch((0.5, 0.5))
+        self.windows.touch((0.5, 0.5))
 
     def test_swipe(self):
         self.windows.swipe((11, 11), (100, 100))
+        self.windows.swipe((0.1, 0.1), (0.5, 0.5))
 
     def test_key_press_and_key_release(self):
         self.windows.key_press('L')

--- a/tests/test_win.py
+++ b/tests/test_win.py
@@ -39,8 +39,11 @@ class TestWin(unittest.TestCase):
         self.windows.touch((100, 100))
         self.windows.touch((0.5, 0.5))
 
+    def test_double_click(self):
+        self.windows.double_click((100, 100))
+
     def test_swipe(self):
-        self.windows.swipe((11, 11), (100, 100))
+        self.windows.swipe((100, 100), (500, 500))
         self.windows.swipe((0.1, 0.1), (0.5, 0.5))
 
     def test_key_press_and_key_release(self):

--- a/tests/test_yosemite.py
+++ b/tests/test_yosemite.py
@@ -1,5 +1,5 @@
 # encoding=utf-8
-from airtest.core.android.android import ADB, Javacap, YosemiteIme
+from airtest.core.android.android import ADB, Javacap, YosemiteIme, YosemiteExt
 from airtest.aircv.utils import string_2_img
 from numpy import ndarray
 import unittest
@@ -66,6 +66,33 @@ class TestIme(unittest.TestCase):
 
     def test_end(cls):
         cls.ime.end()
+
+
+class TestYosemiteExt(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.adb = ADB()
+        devices = cls.adb.devices()
+        if not devices:
+            raise RuntimeError("At lease one adb device required")
+        cls.adb.serialno = devices[0][0]
+        cls.yosemite = YosemiteExt(cls.adb)
+
+    def test_change_lang(self):
+        self.yosemite.change_lang("ja")
+        self.yosemite.change_lang("zh")
+
+    def test_clipboard(self):
+        text1 = "test clipboard"
+        self.yosemite.set_clipboard(text1)
+        self.assertEqual(self.yosemite.get_clipboard(), text1)
+
+        # test escape special char
+        text2 = "test clipboard with $pecial char #@!#%$#^&*()'"
+        self.yosemite.set_clipboard(text2)
+        self.assertEqual(self.yosemite.get_clipboard(), text2)
+
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
ADD:

- `touch`, `swipe`接口新增相对坐标的支持
  - 例如点击中心点 touch((0.5, 0.5))
  - 从右往左滑动 swipe((0.7, 0.5), (0.2, 0.5))
  - 目前android/ios/win都支持
- windows新增了剪贴板相关的接口
  - `get_clipboard` 获取剪贴板内容，`set_clipboard` 设置剪贴板内容， `paste` 粘贴
  - 因此如果有大段文字需要输入，原本使用text接口将会一个一个输入，效率很低，现在可以使用`set_clipboard` 设置到剪贴板之后，再使用`paste`粘贴即可
  - 剪贴板三个接口目前win/ios/android都支持了
- Android支持手动指定`touch_method`，来强制指定`ADBTOUCH`, 或 `MINITOUCH`, `MAXTOUCH`
  -  `dev.touch_method = "ADBTOUCH"`

FIX:

- Yosemite.apk更新，新增了判断输入法是否完全启动的接口，避免输入失败 
- 修复了某些低版本iOS设备使用swipe接口会报错的问题（报错信息为：`Invalid parameter not satisfying: allAttributesForKey != nil`）
- 修复了1.3.2版本引入的adb路径为None的bug
- 修复了部分安卓设备屏幕只显示一半，并且无法恢复的问题