### PR TITLE
chore: change distutils to packaging

### DIFF
--- a/airtest/core/settings.py
+++ b/airtest/core/settings.py
@@ -2,7 +2,7 @@
 from airtest.utils.resolution import cocos_min_strategy
 import os
 import cv2
-from distutils.version import LooseVersion
+from packaging.version import Version, parse
 
 
 class Settings(object):
@@ -13,7 +13,7 @@ class Settings(object):
     RESIZE_METHOD = staticmethod(cocos_min_strategy)
     # keypoint matching: kaze/brisk/akaze/orb, contrib: sift/surf/brief
     CVSTRATEGY = ["mstpl", "tpl", "sift", "brisk"]
-    if LooseVersion('3.4.2') < LooseVersion(cv2.__version__) < LooseVersion('4.4.0'):
+    if Version('3.4.2') < parse(cv2.__version__) < Version('4.4.0'):
         CVSTRATEGY = ["mstpl", "tpl", "brisk"]
     KEYPOINT_MATCHING_PREDICTION = True
     THRESHOLD = 0.7  # [0, 1]

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ filelock
 ffmpeg-python
 tidevice
 psutil
+packaging


### PR DESCRIPTION
distutils module is deprecated in python 3.12, switch to packaging