### PR TITLE
Update ios.py

### DIFF
--- a/airtest/core/ios/ios.py
+++ b/airtest/core/ios/ios.py
@@ -648,7 +648,14 @@ class IOS(Device):
                 self.udid = udid
             else:
                 self.udid = parsed
-            self.driver = wda.USBClient(udid=self.udid, port=8100, wda_bundle_id=self.wda_bundle_id)
+                self.driver = wda.USBClient(udid=self.udid, port=8100, wda_bundle_id=self.wda_bundle_id)
+            except Exception as e:
+                # windows connect ios devices fail:USBClient.__init__() got an unexpected keyword argument 'wda_bundle_id'
+                LOGGING.warning("USBClient.__init__()  error: {msg}".format(msg=e))
+                self.driver = wda.USBClient(udid=self.udid, port=8100)
+                
+                
+            
         # Record device's width and height.
         self._size = {'width': None, 'height': None}
         self._current_orientation = None


### PR DESCRIPTION
windows connect ios devices fail:USBClient.__init__() got an unexpected keyword argument 'wda_bundle_id'

Windows平台连接ios设备会报这个错误，这里加了一层保护，当链接失败的时候去除掉这个参数，实测可以链接成功。