### PR TITLE
Update ios.py

### DIFF
--- a/airtest/core/ios/ios.py
+++ b/airtest/core/ios/ios.py
@@ -648,7 +648,13 @@ class IOS(Device):
                 self.udid = udid
             else:
                 self.udid = parsed
-            self.driver = wda.USBClient(udid=self.udid, port=8100, wda_bundle_id=self.wda_bundle_id)
+            try:
+                self.driver = wda.USBClient(udid=self.udid, port=8100, wda_bundle_id=self.wda_bundle_id)
+            except Exception as e:
+                # windows connect ios devices fail:USBClient.__init__() got an unexpected keyword argument 'wda_bundle_id'
+                LOGGING.warning("USBClient.__init__()  error: {msg}".format(msg=e))
+                self.driver = wda.USBClient(udid=self.udid, port=8100)
+                
         # Record device's width and height.
         self._size = {'width': None, 'height': None}
         self._current_orientation = None


### PR DESCRIPTION
这里加了一层保护，当我使用Windows平台连接IOS设备时会报如下错误：
windows connect ios devices fail:USBClient.__init__() got an unexpected keyword argument 'wda_bundle_id'

Mac并不会有这个问题，但是为了可以用起来，这里加了一层保护，请检查或合入