### PR TITLE
Update numpy version constraint in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ Pillow>=3.4.0
 requests>=2.11.1
 six>=1.9.0,<=1.16.0
 mss==6.1.0
-numpy<2.0
+numpy<3.0
 opencv-contrib-python>=4.4.0.46, <=4.6.0.66
 facebook-wda==1.5.0
 pywinauto==0.6.3


### PR DESCRIPTION
原先的numpy<2.0版本会在安装依赖的时候失败。