### PR TITLE
fix: adb push file deletion and screencap multi-display error

### DIFF
--- a/airtest/core/android/adb.py
+++ b/airtest/core/android/adb.py
@@ -495,7 +495,7 @@ class ADB(object):
 
         """
         _, ext = os.path.splitext(remote)
-        if ext or os.path.isfile(remote):
+        if ext or os.path.isfile(local):
             # The target path is a file
             dst_parent = os.path.dirname(remote)
         else:
@@ -872,7 +872,7 @@ class ADB(object):
         if self.display_id:
             raw = self.cmd('shell screencap -d {0} -p'.format(self.display_id), ensure_unicode=False)
         else:
-            raw = self.cmd('shell screencap -p', ensure_unicode=False)
+            raw = self.cmd('shell screencap -p 2> /dev/null', ensure_unicode=False)
         return raw.replace(self.line_breaker, b"\n")
 
     # PEP 3113 -- Removal of Tuple Parameter Unpacking

--- a/airtest/core/android/adb.py
+++ b/airtest/core/android/adb.py
@@ -494,52 +494,53 @@ class ADB(object):
             >>> adb.push("test_dir", "/sdcard/Android/data/com.test.package/files/test_dir")
 
         """
-        _, ext = os.path.splitext(remote)
-        if ext or os.path.isfile(local):
-            # The target path is a file
-            dst_parent = os.path.dirname(remote)
+        src_is_file = os.path.isfile(local)
+
+        if src_is_file:
+            # If local file has extension and remote path has no extension, treat remote path as a directory
+            src_ext = os.path.splitext(local)[-1]
+            dst_ext = os.path.splitext(remote)[-1]
+            if dst_ext == '' and src_ext != '':
+                dst_path = f"{remote}/{os.path.basename(local)}"
+            else:
+                dst_path = remote
         else:
-            dst_parent = remote
+            if os.path.basename(local) != os.path.basename(remote):
+                dst_path = f"{remote}/{os.path.basename(local)}"
+            else:
+                dst_path = remote
 
         # If the target file already exists, delete it first to avoid overwrite failure
-        src_filename = os.path.basename(local)
-        _, src_ext = os.path.splitext(local)
-        if src_ext:
-            dst_path = f"{dst_parent}/{src_filename}"
-        else:
-            if src_filename == os.path.basename(remote):
-                dst_path = remote
-            else:
-                dst_path = f"{dst_parent}/{src_filename}"
         try:
             self.shell(f"rm -r {dst_path}")
         except:
             pass
 
         # If the target folder has multiple levels that have never been created, try to create them
+        dst_parent = os.path.dirname(dst_path)
         try:
             self.shell(f"mkdir -p {dst_parent}")
         except:
             pass
 
         # Push the file to the tmp directory to avoid permission issues
-        tmp_path = f"{TMP_PATH}/{src_filename}"
+        tmp_path = f"{TMP_PATH}/{os.path.basename(dst_path)}"
         try:
             self.cmd(["push", local, tmp_path])
         except:
-            self.cmd(["push", local, dst_parent])
+            self.cmd(["push", local, dst_path])
         else:
             try:
-                if src_ext:
+                if src_is_file:
                     try:
-                        self.shell(f'mv "{tmp_path}" "{remote}"')
+                        self.shell(f'mv "{tmp_path}" "{dst_parent}"')
                     except:
-                        self.shell(f'mv "{tmp_path}" "{remote}"')
+                        self.shell(f'mv "{tmp_path}" "{dst_parent}"')
                 else:
                     try:
-                        self.shell(f'cp -frp "{tmp_path}/*" "{remote}"')
+                        self.shell(f'cp -frp "{tmp_path}" "{dst_parent}"')
                     except:
-                        self.shell(f'mv "{tmp_path}" "{remote}"')
+                        self.shell(f'mv "{tmp_path}" "{dst_parent}"')
             finally:
                 try:
                     if TMP_PATH != dst_parent:


### PR DESCRIPTION
## Summary
- Fix `ADB.push()` deleting a local file when its name collides with
  a remote folder name (wrong `isfile()` target).
- Fix `ADB.screenshot()` returning corrupted PNG on multi-display
  devices (e.g. Galaxy Z Flip, Z Fold, LG Wing . . .) due to
  stderr noise mixed into the binary stream.

## Changes
- `adb.py`: check `local` instead of `remote` in `push()` path resolution.
- `adb.py`: redirect stderr to `/dev/null` in `screencap` call.

## Related
- Regression introduced in: https://github.com/AirtestProject/Airtest/commit/a9722c45985ee4fa55c815ac4e66ad2f5264acdc
- Related fix by @jye110: https://github.com/AirtestProject/Airtest/pull/1288/changes